### PR TITLE
feat: redesign simulator layout and game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vite-react-starter",
+  "name": "submarine-orchestration-simulator",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-react-starter",
+      "name": "submarine-orchestration-simulator",
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",

--- a/src/App.css
+++ b/src/App.css
@@ -1,556 +1,660 @@
-.app-shell {
-  background: rgba(14, 21, 38, 0.85);
-  backdrop-filter: blur(16px);
-  border-radius: 28px;
-  padding: 2.5rem;
-  box-shadow: 0 24px 60px rgba(3, 10, 27, 0.6);
+.app-layout {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 1.75rem;
+  height: 100vh;
+  max-height: 100vh;
+  padding: 1.75rem;
+  color: #f2f5ff;
+  background: radial-gradient(circle at top, rgba(17, 32, 58, 0.92), rgba(5, 9, 17, 0.94));
+}
+
+.sidebar {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  background: rgba(10, 17, 31, 0.88);
+  backdrop-filter: blur(10px);
+  border-radius: 24px;
+  border: 1px solid rgba(95, 139, 224, 0.18);
+  overflow: hidden;
+  position: relative;
 }
 
-.app-header h1 {
-  margin: 0;
-  font-size: 2.3rem;
-  letter-spacing: 0.04em;
-}
-
-.app-header p {
-  margin: 0.75rem 0 0;
-  color: rgba(229, 236, 255, 0.8);
-  max-width: 60ch;
-}
-
-.layout {
-  display: grid;
-  grid-template-columns: 1.2fr 1fr;
-  gap: 1.75rem;
-  align-items: start;
-}
-
-.submarine-diagram {
-  background: linear-gradient(135deg, rgba(40, 58, 92, 0.6), rgba(19, 30, 53, 0.75));
-  border-radius: 22px;
-  padding: 1.5rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
-}
-
-.submarine-diagram svg {
-  width: 100%;
-  height: auto;
-  font-size: 0.65rem;
-  fill: #fff;
-}
-
-.submarine-diagram text {
-  text-anchor: middle;
-  pointer-events: none;
-}
-
-.submarine-diagram .compartment {
-  cursor: pointer;
-  transition: transform 180ms ease, filter 180ms ease;
-}
-
-.submarine-diagram .compartment:hover {
-  transform: scale(1.02);
-  filter: drop-shadow(0 0 6px rgba(76, 139, 245, 0.45));
-}
-
-.submarine-diagram .compartment text {
-  fill: #f4f7ff;
-}
-
-.compartment-details {
-  background: rgba(8, 13, 24, 0.72);
-  border-radius: 22px;
-  padding: 1.5rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
-  display: grid;
-  gap: 1rem;
-}
-
-.compartment-details h2 {
-  margin: 0;
-  font-size: 1.4rem;
-}
-
-.compartment-details h3 {
-  margin: 0.75rem 0 0.35rem;
-  font-size: 1rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(176, 200, 255, 0.8);
-}
-
-.compartment-details ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  gap: 0.25rem;
-}
-
-.empty {
-  color: rgba(200, 214, 245, 0.6);
-  font-style: italic;
-}
-
-.tab-bar {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 0.5rem;
-}
-
-.tab {
-  background: rgba(16, 24, 41, 0.8);
-  border: 1px solid rgba(80, 112, 183, 0.2);
-  color: rgba(226, 233, 255, 0.75);
-  padding: 0.75rem 1rem;
-  border-radius: 14px;
-  transition: border-color 140ms ease, color 140ms ease, background 140ms ease;
-}
-
-.tab:hover {
-  border-color: rgba(132, 170, 255, 0.5);
-  color: #fff;
-}
-
-.tab.active {
-  background: linear-gradient(135deg, rgba(76, 139, 245, 0.32), rgba(42, 89, 198, 0.6));
-  border-color: rgba(160, 196, 255, 0.7);
-  color: #fff;
-}
-
-.tab-content {
-  display: grid;
-}
-
-.panel {
-  background: rgba(9, 14, 26, 0.88);
-  border-radius: 22px;
-  box-shadow: inset 0 0 0 1px rgba(116, 145, 214, 0.14);
-  padding: 1.8rem;
-  display: grid;
-  gap: 1.5rem;
-}
-
-.panel header {
+.sidebar-header {
+  padding: 1.5rem 1.75rem;
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
+  flex-direction: column;
   gap: 1rem;
+  background: linear-gradient(135deg, rgba(46, 83, 170, 0.35), rgba(12, 21, 40, 0.9));
 }
 
-.panel h2 {
-  margin: 0;
+.sidebar-header h1 {
   font-size: 1.5rem;
+  margin: 0;
+  line-height: 1.2;
 }
 
-.panel-description {
-  margin: 0.35rem 0 0;
-  color: rgba(200, 214, 245, 0.7);
-}
-
-.panel-actions {
-  color: rgba(150, 178, 242, 0.8);
+.sidebar-header p {
+  margin: 0;
+  color: rgba(203, 216, 244, 0.8);
   font-size: 0.95rem;
 }
 
-.inline-form {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  align-items: end;
-  background: rgba(14, 21, 38, 0.7);
-  padding: 1.25rem;
-  border-radius: 18px;
-  box-shadow: inset 0 0 0 1px rgba(80, 112, 183, 0.25);
+.milestone-button {
+  align-self: flex-start;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(137, 172, 255, 0.4);
+  background: rgba(21, 35, 66, 0.8);
+  color: #f2f6ff;
+  cursor: pointer;
+  transition: border-color 150ms ease, transform 150ms ease;
 }
 
-.inline-form label,
-.inline-form legend {
+.milestone-button:hover {
+  border-color: rgba(173, 203, 255, 0.8);
+  transform: translateY(-1px);
+}
+
+.sidebar-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  padding: 1rem 1.5rem 0.5rem;
+}
+
+.sidebar-tab {
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(80, 112, 183, 0.35);
+  background: rgba(12, 21, 39, 0.75);
+  color: rgba(223, 231, 255, 0.7);
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+}
+
+.sidebar-tab:hover {
+  border-color: rgba(136, 170, 243, 0.7);
+  color: #fff;
+}
+
+.sidebar-tab.active {
+  background: linear-gradient(135deg, rgba(92, 142, 242, 0.45), rgba(48, 82, 167, 0.9));
+  border-color: rgba(151, 189, 255, 0.8);
+  color: #fff;
+}
+
+.sidebar-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 1.75rem 1.5rem;
+  display: grid;
+}
+
+.sidebar-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.sidebar-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  background: rgba(12, 20, 39, 0.75);
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(84, 111, 187, 0.35);
+}
+
+.sidebar-form .form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.sidebar-form .form-row.wide,
+.sidebar-form textarea,
+.sidebar-form .assignees {
+  grid-column: span 2;
+}
+
+.sidebar-form label,
+.sidebar-form legend {
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(159, 188, 247, 0.75);
-  display: block;
-  margin-bottom: 0.35rem;
+  color: rgba(185, 205, 245, 0.7);
 }
 
-.inline-form input,
-.inline-form textarea,
-.inline-form select {
-  width: 100%;
+.sidebar-form input,
+.sidebar-form textarea,
+.sidebar-form select {
   border-radius: 12px;
-  border: 1px solid rgba(82, 107, 171, 0.45);
-  background: rgba(6, 11, 22, 0.9);
-  color: #f2f6ff;
-  padding: 0.6rem 0.75rem;
+  border: 1px solid rgba(84, 111, 187, 0.4);
+  background: rgba(6, 12, 24, 0.92);
+  color: #f4f6ff;
+  padding: 0.55rem 0.75rem;
   font-size: 0.95rem;
-  transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
-.inline-form textarea {
+.sidebar-form textarea {
   resize: vertical;
+  min-height: 2.5rem;
 }
 
-.inline-form input:focus,
-.inline-form textarea:focus,
-.inline-form select:focus {
-  outline: none;
-  border-color: rgba(124, 166, 255, 0.85);
-  box-shadow: 0 0 0 2px rgba(124, 166, 255, 0.3);
-}
-
-.inline-form fieldset {
-  border: 1px solid rgba(82, 107, 171, 0.45);
-  border-radius: 16px;
+.sidebar-form fieldset {
+  border: 1px dashed rgba(84, 111, 187, 0.35);
+  border-radius: 14px;
   padding: 0.75rem;
   display: grid;
   gap: 0.4rem;
 }
 
-.inline-form fieldset label {
+.sidebar-form fieldset label {
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: 0.85rem;
+  color: rgba(226, 234, 255, 0.8);
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  text-transform: none;
-  letter-spacing: normal;
 }
 
-.inline-form .wide {
-  grid-column: 1 / -1;
-}
-
-.inline-form button.primary {
-  grid-column: 1 / -1;
-  justify-self: flex-end;
-}
-
-button {
-  border-radius: 12px;
-  border: 1px solid rgba(82, 107, 171, 0.65);
-  padding: 0.55rem 1.3rem;
-  font-size: 0.95rem;
-  background: rgba(16, 24, 41, 0.8);
-  color: #f0f4ff;
+.primary {
+  grid-column: span 2;
+  margin-top: 0.5rem;
+  background: linear-gradient(135deg, rgba(99, 152, 255, 0.85), rgba(64, 102, 199, 0.95));
+  border: none;
+  border-radius: 14px;
+  padding: 0.65rem 1.2rem;
+  color: #f8fbff;
+  font-weight: 600;
   cursor: pointer;
-  transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+  transition: transform 150ms ease, box-shadow 150ms ease;
 }
 
-button.primary {
-  background: linear-gradient(135deg, rgba(76, 139, 245, 0.65), rgba(40, 92, 214, 0.8));
-  border-color: rgba(152, 182, 253, 0.9);
-}
-
-button:hover {
+.primary:hover {
   transform: translateY(-1px);
-  border-color: rgba(132, 170, 255, 0.8);
+  box-shadow: 0 8px 22px rgba(32, 61, 138, 0.45);
 }
 
-button:focus-visible {
-  outline: 3px solid rgba(132, 170, 255, 0.6);
-  outline-offset: 2px;
-}
-
-.crew-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1.25rem;
-}
-
-.crew-card {
-  background: rgba(16, 24, 41, 0.6);
-  border-radius: 18px;
-  padding: 1.2rem;
-  box-shadow: inset 0 0 0 1px rgba(82, 107, 171, 0.3);
+.crew-list,
+.task-list,
+.team-grid {
   display: grid;
   gap: 1rem;
 }
 
+.crew-card,
+.task-card,
+.team-card {
+  background: rgba(8, 15, 29, 0.85);
+  border-radius: 18px;
+  border: 1px solid rgba(85, 119, 198, 0.18);
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
 .crew-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.crew-card h2,
+.task-card h2,
+.team-card h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.crew-card p,
+.task-card p,
+.team-card p {
+  margin: 0;
+  color: rgba(208, 220, 247, 0.75);
+  font-size: 0.92rem;
+}
+
+.crew-station {
+  background: rgba(82, 116, 205, 0.28);
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(212, 223, 255, 0.85);
+}
+
+.crew-card dl,
+.task-card dl {
+  margin: 0;
   display: grid;
   gap: 0.5rem;
 }
 
-.crew-card h3 {
-  margin: 0;
-}
-
-.crew-meta {
-  display: grid;
-  gap: 0.35rem;
-  font-size: 0.85rem;
-}
-
-.crew-meta span {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.crew-meta input,
-.crew-meta select {
-  flex: 1;
-  border-radius: 10px;
-  border: 1px solid rgba(82, 107, 171, 0.4);
-  padding: 0.35rem 0.5rem;
-  background: rgba(9, 14, 26, 0.85);
-  color: #f2f6ff;
-}
-
-.crew-section h4 {
-  margin: 0 0 0.35rem;
-  font-size: 0.9rem;
+.crew-card dt,
+.task-card dt {
+  font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(159, 188, 247, 0.75);
+  color: rgba(156, 183, 238, 0.7);
 }
 
-.crew-section textarea {
-  width: 100%;
-  border-radius: 12px;
-  border: 1px solid rgba(82, 107, 171, 0.4);
-  background: rgba(9, 14, 26, 0.85);
-  color: #f2f6ff;
-  padding: 0.5rem 0.6rem;
-  resize: vertical;
-}
-
-.task-board {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.25rem;
-}
-
-.task-card {
-  background: rgba(16, 24, 41, 0.6);
-  border-radius: 18px;
-  padding: 1.3rem;
-  box-shadow: inset 0 0 0 1px rgba(82, 107, 171, 0.35);
-  display: grid;
-  gap: 0.9rem;
-}
-
-.task-card header h3 {
-  margin: 0 0 0.35rem;
-}
-
-.task-card header p {
+.crew-card dd,
+.task-card dd {
   margin: 0;
-  color: rgba(205, 218, 245, 0.75);
+  color: rgba(230, 237, 255, 0.85);
+}
+
+.crew-controls {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.crew-controls label {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(173, 197, 244, 0.7);
+}
+
+.crew-controls input,
+.crew-controls select {
+  border-radius: 10px;
+  border: 1px solid rgba(88, 118, 203, 0.35);
+  background: rgba(10, 16, 31, 0.85);
+  color: #f2f6ff;
+  padding: 0.45rem 0.65rem;
+}
+
+.crew-instructions-editor {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(173, 197, 244, 0.7);
+}
+
+.crew-instructions-editor textarea {
+  border-radius: 12px;
+  border: 1px solid rgba(88, 118, 203, 0.35);
+  background: rgba(6, 12, 24, 0.9);
+  color: #f5f8ff;
+  padding: 0.55rem 0.75rem;
+  min-height: 3.5rem;
+}
+
+.task-card header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
 }
 
 .status-chip {
-  background: rgba(76, 139, 245, 0.25);
-  border: 1px solid rgba(76, 139, 245, 0.55);
-  color: #a7c6ff;
+  align-self: flex-start;
+  padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  padding: 0.15rem 0.6rem;
+  background: rgba(98, 152, 255, 0.25);
   font-size: 0.75rem;
-  letter-spacing: 0.05em;
   text-transform: uppercase;
-}
-
-dl {
-  display: grid;
-  gap: 0.4rem;
-  margin: 0;
-}
-
-dl div {
-  display: grid;
-  gap: 0.15rem;
-}
-
-dl dt {
-  font-size: 0.75rem;
   letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(159, 188, 247, 0.7);
-}
-
-dl dd {
-  margin: 0;
-  color: rgba(226, 233, 255, 0.8);
 }
 
 .task-card footer {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  justify-content: flex-end;
 }
 
-.task-card .completed {
-  color: #9ddba0;
+.task-card footer button {
+  background: rgba(95, 139, 224, 0.45);
+  border: none;
+  border-radius: 12px;
+  padding: 0.5rem 0.9rem;
+  color: #f4f8ff;
+  cursor: pointer;
+  transition: background 140ms ease;
 }
 
-.team-grid {
+.task-card footer button:hover {
+  background: rgba(123, 168, 255, 0.65);
+}
+
+.completed {
+  color: rgba(173, 214, 255, 0.85);
+  font-weight: 600;
+}
+
+.team-card ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.25rem;
+  gap: 0.25rem;
+  color: rgba(214, 225, 248, 0.85);
 }
 
-.team-card {
-  background: rgba(16, 24, 41, 0.6);
-  border-radius: 18px;
-  padding: 1.2rem;
-  box-shadow: inset 0 0 0 1px rgba(82, 107, 171, 0.35);
-  display: grid;
-  gap: 1rem;
-}
-
-.team-card header h3 {
-  margin: 0 0 0.25rem;
-}
-
-.team-card header p {
-  margin: 0;
-  color: rgba(205, 218, 245, 0.75);
-}
-
-.team-members ul,
-.team-matrix ul {
+.stations-panel ul {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.3rem;
+  gap: 1rem;
 }
 
-.team-matrix table {
-  width: 100%;
-  border-collapse: collapse;
+.stations-panel li {
+  background: rgba(8, 15, 29, 0.8);
+  border-radius: 16px;
+  border: 1px solid rgba(85, 119, 198, 0.18);
+  padding: 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.station-metric {
+  margin: 0;
+  color: rgba(192, 210, 247, 0.75);
   font-size: 0.85rem;
 }
 
-.team-matrix th,
-.team-matrix td {
-  border-bottom: 1px solid rgba(82, 107, 171, 0.2);
-  padding: 0.35rem 0;
-  text-align: left;
-}
-
-.team-matrix th {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.7rem;
-  color: rgba(159, 188, 247, 0.7);
-}
-
-.tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  border-radius: 999px;
-  padding: 0.1rem 0.6rem;
-  border: 1px solid rgba(82, 107, 171, 0.6);
-  color: rgba(204, 222, 255, 0.75);
-}
-
-.configuration-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.25rem;
-}
-
-.configuration-card {
-  background: rgba(16, 24, 41, 0.6);
-  border-radius: 18px;
-  padding: 1.2rem;
-  box-shadow: inset 0 0 0 1px rgba(82, 107, 171, 0.3);
+.achievement-summary {
+  padding: 1rem 1.75rem 1.5rem;
+  background: rgba(9, 15, 28, 0.9);
+  border-top: 1px solid rgba(70, 104, 186, 0.18);
   display: grid;
   gap: 0.75rem;
 }
 
-.configuration-card header h3 {
-  margin: 0 0 0.35rem;
-}
-
-.configuration-card header p {
+.achievement-summary h2 {
   margin: 0;
-  color: rgba(205, 218, 245, 0.75);
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(179, 203, 245, 0.8);
 }
 
-.log-list {
+.achievement-summary ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.achievement-summary li {
+  display: grid;
+  gap: 0.3rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 12px;
+  background: rgba(15, 24, 44, 0.7);
+  border: 1px solid transparent;
+}
+
+.achievement-summary li.achieved {
+  border-color: rgba(118, 172, 255, 0.6);
+  background: rgba(35, 57, 101, 0.8);
+}
+
+.achievement-summary small {
+  color: rgba(206, 217, 245, 0.7);
+}
+
+.milestone-drawer {
+  position: absolute;
+  inset: 1.25rem;
+  border-radius: 20px;
+  background: rgba(9, 14, 26, 0.96);
+  border: 1px solid rgba(110, 150, 232, 0.35);
+  padding: 1.5rem;
   display: grid;
   gap: 1rem;
+  z-index: 3;
 }
 
-.log-entry {
-  background: rgba(16, 24, 41, 0.6);
-  border-radius: 18px;
-  padding: 1.2rem;
-  box-shadow: inset 0 0 0 1px rgba(82, 107, 171, 0.35);
-  display: grid;
-  gap: 0.6rem;
-}
-
-.log-entry header {
+.milestone-drawer header {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
   gap: 1rem;
 }
 
-.log-entry h3 {
+.milestone-drawer button {
+  border: none;
+  background: rgba(66, 96, 173, 0.6);
+  padding: 0.5rem 1rem;
+  border-radius: 12px;
+  color: #f6f8ff;
+  cursor: pointer;
+}
+
+.milestone-drawer ul {
+  list-style: none;
   margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.milestone-drawer li {
+  background: rgba(14, 21, 38, 0.8);
+  border-radius: 14px;
+  border: 1px solid rgba(92, 132, 214, 0.25);
+  padding: 0.9rem 1rem;
+}
+
+.milestone-drawer li.achieved {
+  border-color: rgba(142, 183, 255, 0.65);
+}
+
+.main-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  height: 100%;
+}
+
+.game-area {
+  background: rgba(8, 13, 24, 0.9);
+  border-radius: 26px;
+  border: 1px solid rgba(88, 125, 212, 0.2);
+  padding: 1.25rem 1.5rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.achievement-track {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.achievement {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(12, 21, 39, 0.75);
+  padding: 0.45rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  color: rgba(207, 220, 248, 0.7);
+  border: 1px solid rgba(65, 98, 176, 0.4);
+}
+
+.achievement.achieved {
+  background: rgba(56, 94, 178, 0.85);
+  color: #f6f8ff;
+  border-color: rgba(121, 170, 255, 0.8);
+  box-shadow: 0 0 12px rgba(86, 133, 230, 0.45);
+}
+
+.achievement-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.game-viewport {
+  position: relative;
+  border-radius: 22px;
+  overflow: hidden;
+  border: 1px solid rgba(72, 104, 186, 0.25);
+}
+
+.game-canvas {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.port-label {
+  fill: rgba(206, 220, 248, 0.75);
+  font-size: 0.8rem;
+  text-anchor: middle;
+}
+
+.stats-overlay {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  display: grid;
+  gap: 0.35rem;
+  background: rgba(10, 17, 30, 0.72);
+  border-radius: 14px;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid rgba(80, 113, 194, 0.35);
+  font-size: 0.85rem;
+}
+
+.stats-overlay strong {
+  display: block;
+  color: #f6f8ff;
+  font-weight: 600;
+}
+
+.control-panel {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.control-panel button {
+  background: rgba(60, 97, 182, 0.75);
+  border: none;
+  border-radius: 12px;
+  padding: 0.45rem 0.75rem;
+  color: #f2f6ff;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 140ms ease;
+}
+
+.control-panel button:hover {
+  background: rgba(92, 134, 222, 0.85);
+}
+
+.achievement-popup {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: rgba(68, 105, 194, 0.88);
+  border-radius: 18px;
+  padding: 0.75rem 1.1rem;
+  color: #f8fbff;
+  box-shadow: 0 14px 32px rgba(28, 52, 104, 0.45);
+  animation: slideDown 400ms ease;
+}
+
+.achievement-popup + .achievement-popup {
+  margin-top: 3.5rem;
+}
+
+@keyframes slideDown {
+  from {
+    transform: translateY(-10px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.ship-log {
+  background: rgba(8, 13, 24, 0.9);
+  border-radius: 24px;
+  border: 1px solid rgba(80, 116, 203, 0.2);
+  padding: 1.25rem 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.ship-log h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(178, 199, 241, 0.8);
+}
+
+.log-bubble {
+  background: rgba(12, 20, 38, 0.85);
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(74, 110, 194, 0.25);
+}
+
+.log-bubble ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
 }
 
 .log-meta {
   display: flex;
-  gap: 0.75rem;
-  align-items: center;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  color: rgba(181, 204, 244, 0.8);
   font-size: 0.85rem;
-  color: rgba(173, 195, 240, 0.8);
 }
 
-.log-type {
-  padding: 0.1rem 0.6rem;
-  border-radius: 999px;
-  border: 1px solid rgba(76, 139, 245, 0.6);
-  background: rgba(76, 139, 245, 0.2);
+.log-speaker {
+  font-weight: 600;
 }
 
-.log-entry p {
-  margin: 0;
-  color: rgba(219, 230, 255, 0.82);
+.log-bubble p {
+  margin: 0.25rem 0 0;
+  color: rgba(226, 233, 255, 0.9);
 }
 
-@media (max-width: 960px) {
-  body {
-    padding: 1.5rem;
-  }
-
-  .app-shell {
-    padding: 1.75rem;
-  }
-
-  .layout {
+@media (max-width: 1180px) {
+  .app-layout {
     grid-template-columns: 1fr;
+    height: auto;
+    max-height: none;
   }
 
-  .compartment-details {
-    order: -1;
-  }
-}
-
-@media (max-width: 640px) {
-  body {
-    padding: 1rem;
+  .sidebar {
+    max-height: min(620px, 90vh);
   }
 
-  .app-shell {
-    padding: 1.25rem;
-    gap: 1.5rem;
-  }
-
-  .inline-form {
-    grid-template-columns: 1fr;
-  }
-
-  .tab-bar {
-    grid-template-columns: 1fr;
+  .main-column {
+    min-height: 600px;
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,27 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import './App.css'
 
 const compartments = [
   {
     id: 'bridge',
     name: 'Bridge',
-    description: 'Command deck overseeing mission goals and navigation vectors.',
-    resources: ['Mission console', 'Strategic chart table', 'Encrypted comms array'],
-    coordinates: { x: 20, y: 35, width: 30, height: 18 },
+    description:
+      'Command deck coordinating navigation choices, tactical approvals, and the overall mission vector.',
   },
   {
     id: 'sonar',
     name: 'Sonar & Recon',
-    description: 'Sensor suite decoding sonar sweeps and environmental readings.',
-    resources: ['Hydrophone cluster', 'Pattern recognition AI copilot'],
-    coordinates: { x: 55, y: 25, width: 25, height: 22 },
+    description: 'Sensor suite decoding sonar sweeps and environmental readings in real time.',
   },
   {
     id: 'torpedo',
     name: 'Torpedo Bay',
-    description: 'Armaments staging with missile launch and reload control.',
-    resources: ['Guidance calibration rig', 'Payload safety interlocks'],
-    coordinates: { x: 15, y: 60, width: 32, height: 20 },
+    description: 'Armaments staging with missile launch controls and reload teams.',
   },
   {
     id: 'engineering',
     name: 'Engineering',
     description: 'Propulsion, damage control, and reactor tuning for quiet running.',
-    resources: ['Reactor diagnostics deck', 'Damage control lockers'],
-    coordinates: { x: 52, y: 60, width: 28, height: 20 },
   },
 ]
 
@@ -39,7 +32,7 @@ const initialCrew = [
     role: 'Commanding Officer',
     compartment: 'bridge',
     instructions:
-      'Coordinate all tasking. Keep sonar and engineering timelines synchronized before approving torpedo launches.',
+      'Keep sonar and engineering timelines synchronized before approving torpedo launches. Authorize depth changes deliberately.',
   },
   {
     id: 'sonar-lead',
@@ -70,23 +63,22 @@ const initialCrew = [
 const initialTasks = [
   {
     id: 'task-1',
-    title: 'Chart Thermal Vent Field',
-    objective: 'Map thermal vents to locate safe passage for survey drones.',
-    compartmentFocus: 'sonar',
+    title: 'Transit Left Port',
+    objective: 'Exit the western harbor quietly and maintain sonar coverage.',
+    compartmentFocus: 'bridge',
     assignees: ['captain', 'sonar-lead'],
     status: 'In Progress',
     reasoning:
-      'Bridge needs continuous sensor updates; sonar lead triangulates vent plumes and posts summary to command.',
+      'Bridge keeps helm decisions in sync with sonar sweeps. Tactical remains on standby while engineering stages propulsion.',
   },
   {
     id: 'task-2',
-    title: 'Quiet Reactor Rebalance',
-    objective: 'Reduce cavitation noise before covert transit segment.',
+    title: 'Depth Envelope Validation',
+    objective: 'Test ballast adjustments to keep a safe ride height above the ocean floor.',
     compartmentFocus: 'engineering',
     assignees: ['engineer'],
     status: 'Planned',
-    reasoning:
-      'Engineering will stagger coolant cycle adjustments and request power windows from the bridge team.',
+    reasoning: 'Engineering cycles pumps while sonar monitors bottom terrain for hazards.',
   },
 ]
 
@@ -114,139 +106,902 @@ const initialTeams = [
 const initialLog = [
   {
     id: 'log-1',
+    speaker: 'Captain Chen',
+    tone: 'command',
     timestamp: new Date().toISOString(),
-    title: 'Mission Brief Uploaded',
-    type: 'Overview',
-    narrative:
-      'Crew assembled on the bridge to review mission tasks. Command net agreed to prioritize vent mapping before stealth transit.',
+    message: 'Bridge briefed on harbor departure. Navigation plotting a line that skirts enemy patrol arcs.',
   },
   {
     id: 'log-2',
+    speaker: 'Ensign Park',
+    tone: 'sonar',
     timestamp: new Date().toISOString(),
-    title: 'Task Allocation Review',
-    type: 'Coordination',
-    narrative:
-      'Captain Chen synchronized sonar sweeps with engineering power cycles. Weapons chief remains on ready posture awaiting contact data.',
+    message: 'Sonar buoys calibrated. Ready to feed contour data to engineering as we descend.',
   },
 ]
 
-function SubmarineDiagram({
-  compartments,
-  selectedCompartment,
-  onSelect,
-  crewCountByCompartment,
-}) {
-  return (
-    <div className="submarine-diagram">
-      <svg viewBox="0 0 120 80" role="img" aria-label="Top-down submarine layout">
-        <defs>
-          <linearGradient id="hullGradient" x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0%" stopColor="#1f2a44" />
-            <stop offset="100%" stopColor="#101829" />
-          </linearGradient>
-        </defs>
-        <path
-          d="M5 40 C10 20, 40 10, 85 15 L110 15 C114 15, 118 25, 118 40 C118 55, 114 65, 110 65 L85 65 C40 70, 10 60, 5 40 Z"
-          fill="url(#hullGradient)"
-          stroke="#0b1423"
-          strokeWidth="1"
-        />
-        {compartments.map((compartment) => {
-          const { coordinates } = compartment
-          const isSelected = compartment.id === selectedCompartment
-          return (
-            <g
-              key={compartment.id}
-              className={isSelected ? 'compartment selected' : 'compartment'}
-              onClick={() => onSelect(compartment.id)}
-            >
-              <rect
-                x={coordinates.x}
-                y={coordinates.y}
-                width={coordinates.width}
-                height={coordinates.height}
-                rx={3}
-                ry={3}
-                fill={isSelected ? 'rgba(76, 139, 245, 0.55)' : 'rgba(255, 255, 255, 0.18)'}
-                stroke={isSelected ? '#4c8bf5' : 'rgba(255,255,255,0.35)'}
-                strokeWidth={isSelected ? 2 : 1}
-              />
-              <text x={coordinates.x + coordinates.width / 2} y={coordinates.y + coordinates.height / 2}>
-                {compartment.name}
-              </text>
-              <text
-                className="compartment-count"
-                x={coordinates.x + coordinates.width / 2}
-                y={coordinates.y + coordinates.height / 2 + 10}
-              >
-                {crewCountByCompartment[compartment.id] || 0} crew
-              </text>
-            </g>
-          )
-        })}
-      </svg>
-    </div>
-  )
+const achievementCatalog = [
+  {
+    id: 'ach-distance-100',
+    label: 'Harbor Wake',
+    description: 'Travel more than 100 meters from the left port.',
+    type: 'distance',
+    value: 100,
+  },
+  {
+    id: 'ach-depth-120',
+    label: 'Into the Blue',
+    description: 'Descend beyond 120 meters without scraping the seafloor.',
+    type: 'depth',
+    value: 120,
+  },
+  {
+    id: 'ach-distance-600',
+    label: 'Midway Vector',
+    description: 'Surge past the midpoint between ports while remaining undetected.',
+    type: 'distance',
+    value: 600,
+  },
+  {
+    id: 'ach-bots-avoided',
+    label: 'Ghosted Rivals',
+    description: 'Avoid all bot submarines for two minutes of continuous travel.',
+    type: 'avoidance',
+    value: 120,
+  },
+  {
+    id: 'ach-arrival',
+    label: 'Right Port Secure',
+    description: 'Reach the eastern harbor without striking the ocean floor.',
+    type: 'arrival',
+  },
+]
+
+const MAX_DEPTH = 360
+const MIN_DEPTH = 30
+const VIEWPORT_WIDTH = 960
+const VIEWPORT_HEIGHT = 520
+const SEA_FLOOR = VIEWPORT_HEIGHT - 60
+const SURFACE_LEVEL = 60
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value))
 }
 
-function Section({ title, description, children, actions }) {
-  return (
-    <section className="panel">
-      <header>
-        <div>
-          <h2>{title}</h2>
-          {description && <p className="panel-description">{description}</p>}
-        </div>
-        {actions && <div className="panel-actions">{actions}</div>}
-      </header>
-      <div className="panel-body">{children}</div>
-    </section>
-  )
-}
-
-function TabBar({ activeTab, onSelect }) {
-  const tabs = [
-    { id: 'crew', label: 'Crew & Roles' },
-    { id: 'tasks', label: 'Mission Tasks' },
-    { id: 'teams', label: 'Chain of Command' },
-    { id: 'configuration', label: 'Configuration Guide' },
-    { id: 'log', label: "Ship's Log" },
-  ]
-  return (
-    <nav className="tab-bar" aria-label="Submarine coordination views">
-      {tabs.map((tab) => (
-        <button
-          key={tab.id}
-          type="button"
-          className={tab.id === activeTab ? 'tab active' : 'tab'}
-          onClick={() => onSelect(tab.id)}
-        >
-          {tab.label}
-        </button>
-      ))}
-    </nav>
-  )
+function createId(prefix) {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${prefix}-${crypto.randomUUID()}`
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`
 }
 
 function formatTimestamp(isoString) {
   const date = new Date(isoString)
-  return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+  return `${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
 }
 
-let idCounter = 0
-function nextId(prefix) {
-  idCounter += 1
-  return `${prefix}-${idCounter}`
+function AchievementTrack({ achievements }) {
+  return (
+    <div className="achievement-track" aria-label="Mission milestones">
+      {achievements.map((achievement) => (
+        <div
+          key={achievement.id}
+          className={achievement.achieved ? 'achievement achieved' : 'achievement'}
+        >
+          <span className="achievement-dot" />
+          <span className="achievement-label">{achievement.label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ShipLog({ entries }) {
+  return (
+    <section className="ship-log" aria-label="Crew coordination log">
+      <h2>Ship's Log</h2>
+      <div className="log-bubble">
+        <ul>
+          {entries.slice(-6).map((entry) => (
+            <li key={entry.id}>
+              <div className="log-meta">
+                <span className="log-speaker">{entry.speaker}</span>
+                <time>{formatTimestamp(entry.timestamp)}</time>
+              </div>
+              <p>{entry.message}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}
+
+function Sidebar({
+  crew,
+  tasks,
+  teams,
+  activeTab,
+  onChangeTab,
+  compartments,
+  onCrewCompartmentChange,
+  onCrewRoleChange,
+  onCrewInstructionChange,
+  onCrewInstructionBlur,
+  onUpdateTaskStatus,
+  onToggleTaskAssignee,
+  newTask,
+  setNewTask,
+  onAddTask,
+  newCrew,
+  setNewCrew,
+  onAddCrew,
+  achievements,
+  onToggleMilestoneDrawer,
+  isMilestoneDrawerOpen,
+  milestoneDrawer,
+  crewCountByCompartment,
+  tasksByCrew,
+  teamsByCrew,
+}) {
+  return (
+    <aside className="sidebar">
+      <div className="sidebar-header">
+        <div>
+          <h1>Submarine Orchestration Simulator</h1>
+          <p>Direct crew coordination while guiding the submarine safely across the channel.</p>
+        </div>
+        <button
+          type="button"
+          className="milestone-button"
+          onClick={onToggleMilestoneDrawer}
+          aria-expanded={isMilestoneDrawerOpen}
+        >
+          Milestones
+        </button>
+      </div>
+
+      <nav className="sidebar-tabs" aria-label="Crew coordination views">
+        <button
+          type="button"
+          className={activeTab === 'crew' ? 'sidebar-tab active' : 'sidebar-tab'}
+          onClick={() => onChangeTab('crew')}
+        >
+          Crew
+        </button>
+        <button
+          type="button"
+          className={activeTab === 'tasks' ? 'sidebar-tab active' : 'sidebar-tab'}
+          onClick={() => onChangeTab('tasks')}
+        >
+          Mission Tasks
+        </button>
+        <button
+          type="button"
+          className={activeTab === 'teams' ? 'sidebar-tab active' : 'sidebar-tab'}
+          onClick={() => onChangeTab('teams')}
+        >
+          Chain of Command
+        </button>
+        <button
+          type="button"
+          className={activeTab === 'stations' ? 'sidebar-tab active' : 'sidebar-tab'}
+          onClick={() => onChangeTab('stations')}
+        >
+          Stations
+        </button>
+      </nav>
+
+      <div className="sidebar-content">
+        {activeTab === 'crew' && (
+          <div className="sidebar-panel">
+            <form className="sidebar-form" onSubmit={onAddCrew}>
+              <div className="form-row">
+                <label htmlFor="crew-name">Name</label>
+                <input
+                  id="crew-name"
+                  value={newCrew.name}
+                  onChange={(event) => setNewCrew((state) => ({ ...state, name: event.target.value }))}
+                  required
+                  placeholder="Crewmember"
+                />
+              </div>
+              <div className="form-row">
+                <label htmlFor="crew-role">Role</label>
+                <input
+                  id="crew-role"
+                  value={newCrew.role}
+                  onChange={(event) => setNewCrew((state) => ({ ...state, role: event.target.value }))}
+                  required
+                  placeholder="Specialty"
+                />
+              </div>
+              <div className="form-row">
+                <label htmlFor="crew-compartment">Station</label>
+                <select
+                  id="crew-compartment"
+                  value={newCrew.compartment}
+                  onChange={(event) => setNewCrew((state) => ({ ...state, compartment: event.target.value }))}
+                >
+                  {compartments.map((compartment) => (
+                    <option key={compartment.id} value={compartment.id}>
+                      {compartment.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="form-row wide">
+                <label htmlFor="crew-instructions">Instructions</label>
+                <textarea
+                  id="crew-instructions"
+                  value={newCrew.instructions}
+                  onChange={(event) => setNewCrew((state) => ({ ...state, instructions: event.target.value }))}
+                  rows={2}
+                  placeholder="Guidance for the new crewmate"
+                />
+              </div>
+              <button type="submit" className="primary">Add crewmate</button>
+            </form>
+
+            <div className="crew-list">
+              {crew.map((member) => (
+                <article key={member.id} className="crew-card">
+                  <header>
+                    <div>
+                      <h2>{member.name}</h2>
+                      <p>{member.role}</p>
+                    </div>
+                    <span className="crew-station">
+                      {compartments.find((compartment) => compartment.id === member.compartment)?.name}
+                    </span>
+                  </header>
+                  <dl>
+                    <div>
+                      <dt>Assignments</dt>
+                      <dd>{tasksByCrew[member.id]?.map((task) => task.title).join(', ') || 'No tasking'}</dd>
+                    </div>
+                    <div>
+                      <dt>Teams</dt>
+                      <dd>{teamsByCrew[member.id]?.map((team) => team.name).join(', ') || 'Solo watch'}</dd>
+                    </div>
+                  </dl>
+                  <div className="crew-controls">
+                    <label>
+                      Role
+                      <input
+                        value={member.role}
+                        onChange={(event) => onCrewRoleChange(member.id, event.target.value)}
+                      />
+                    </label>
+                    <label>
+                      Station
+                      <select
+                        value={member.compartment}
+                        onChange={(event) => onCrewCompartmentChange(member.id, event.target.value)}
+                      >
+                        {compartments.map((compartment) => (
+                          <option key={compartment.id} value={compartment.id}>
+                            {compartment.name}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+                  <label className="crew-instructions-editor">
+                    Instructions
+                    <textarea
+                      value={member.instructions}
+                      rows={3}
+                      onChange={(event) => onCrewInstructionChange(member.id, event.target.value)}
+                      onBlur={(event) =>
+                        onCrewInstructionBlur(member.id, member.name, event.target.value)
+                      }
+                    />
+                  </label>
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'tasks' && (
+          <div className="sidebar-panel">
+            <form className="sidebar-form" onSubmit={onAddTask}>
+              <div className="form-row">
+                <label htmlFor="task-title">Title</label>
+                <input
+                  id="task-title"
+                  value={newTask.title}
+                  onChange={(event) => setNewTask((state) => ({ ...state, title: event.target.value }))}
+                  placeholder="Objective name"
+                  required
+                />
+              </div>
+              <div className="form-row wide">
+                <label htmlFor="task-objective">Objective</label>
+                <textarea
+                  id="task-objective"
+                  rows={2}
+                  value={newTask.objective}
+                  onChange={(event) => setNewTask((state) => ({ ...state, objective: event.target.value }))}
+                />
+              </div>
+              <div className="form-row">
+                <label htmlFor="task-compartment">Station</label>
+                <select
+                  id="task-compartment"
+                  value={newTask.compartmentFocus}
+                  onChange={(event) =>
+                    setNewTask((state) => ({ ...state, compartmentFocus: event.target.value }))
+                  }
+                >
+                  {compartments.map((compartment) => (
+                    <option key={compartment.id} value={compartment.id}>
+                      {compartment.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <fieldset className="form-row assignees">
+                <legend>Assign crew</legend>
+                {crew.map((member) => (
+                  <label key={member.id}>
+                    <input
+                      type="checkbox"
+                      checked={newTask.assignees.includes(member.id)}
+                      onChange={() => onToggleTaskAssignee(member.id)}
+                    />
+                    {member.name}
+                  </label>
+                ))}
+              </fieldset>
+              <div className="form-row wide">
+                <label htmlFor="task-reasoning">Reasoning</label>
+                <textarea
+                  id="task-reasoning"
+                  rows={2}
+                  value={newTask.reasoning}
+                  onChange={(event) => setNewTask((state) => ({ ...state, reasoning: event.target.value }))}
+                />
+              </div>
+              <button type="submit" className="primary">Register task</button>
+            </form>
+
+            <div className="task-list">
+              {tasks.map((task) => (
+                <article key={task.id} className={`task-card status-${task.status.toLowerCase()}`}>
+                  <header>
+                    <div>
+                      <h2>{task.title}</h2>
+                      <p>{task.objective}</p>
+                    </div>
+                    <span className="status-chip">{task.status}</span>
+                  </header>
+                  <dl>
+                    <div>
+                      <dt>Station</dt>
+                      <dd>
+                        {compartments.find((compartment) => compartment.id === task.compartmentFocus)?.name}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Assignees</dt>
+                      <dd>
+                        {task.assignees
+                          .map((crewId) => crew.find((member) => member.id === crewId)?.name)
+                          .filter(Boolean)
+                          .join(', ') || 'Unassigned'}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Intent</dt>
+                      <dd>{task.reasoning || 'No reasoning filed yet.'}</dd>
+                    </div>
+                  </dl>
+                  <footer>
+                    {task.status !== 'Completed' ? (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          onUpdateTaskStatus(
+                            task.id,
+                            task.status === 'Planned' ? 'In Progress' : 'Completed',
+                          )
+                        }
+                      >
+                        Advance to {task.status === 'Planned' ? 'In Progress' : 'Completed'}
+                      </button>
+                    ) : (
+                      <span className="completed">Ready for review</span>
+                    )}
+                  </footer>
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'teams' && (
+          <div className="sidebar-panel">
+            <div className="team-grid">
+              {teams.map((team) => (
+                <article key={team.id} className="team-card">
+                  <header>
+                    <h2>{team.name}</h2>
+                    <p>{team.function}</p>
+                  </header>
+                  <div>
+                    <h3>Members</h3>
+                    <ul>
+                      {team.members
+                        .map((crewId) => crew.find((member) => member.id === crewId)?.name)
+                        .filter(Boolean)
+                        .map((name) => (
+                          <li key={name}>{name}</li>
+                        ))}
+                    </ul>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'stations' && (
+          <div className="sidebar-panel stations-panel">
+            <ul>
+              {compartments.map((compartment) => (
+                <li key={compartment.id}>
+                  <h2>{compartment.name}</h2>
+                  <p>{compartment.description}</p>
+                  <p className="station-metric">
+                    {crewCountByCompartment[compartment.id] || 0} crew •{' '}
+                    {tasks.filter((task) => task.compartmentFocus === compartment.id).length} active tasks
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      {milestoneDrawer}
+
+      <div className="achievement-summary">
+        <h2>Mission Milestones</h2>
+        <ul>
+          {achievements.map((achievement) => (
+            <li key={achievement.id} className={achievement.achieved ? 'achieved' : undefined}>
+              <span>{achievement.label}</span>
+              <small>{achievement.description}</small>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  )
+}
+
+function GameSimulation({
+  onLog,
+  achievements,
+  onAchievementUnlock,
+  shipHasArrived,
+  onArrival,
+}) {
+  const [submarine, setSubmarine] = useState({
+    x: 80,
+    depth: 80,
+    verticalVelocity: 0,
+    horizontalSpeed: 70,
+    targetDepth: 120,
+    battery: 94,
+    hullIntegrity: 100,
+    distanceTravelled: 0,
+    avoidanceClock: 0,
+  })
+
+  const [enemyBots, setEnemyBots] = useState(() =>
+    Array.from({ length: 3 }, (_, index) => ({
+      id: `bot-${index}`,
+      x: 280 + index * 180,
+      depth: 70 + index * 40,
+      direction: index % 2 === 0 ? 1 : -1,
+      speed: 35 + Math.random() * 20,
+      changeTimer: Math.random() * 6,
+    })),
+  )
+
+  const [fishSchools, setFishSchools] = useState(() =>
+    Array.from({ length: 10 }, (_, index) => ({
+      id: `fish-${index}`,
+      x: Math.random() * VIEWPORT_WIDTH,
+      depth: 40 + Math.random() * (MAX_DEPTH - 40),
+      speed: 15 + Math.random() * 10,
+      direction: Math.random() > 0.5 ? 1 : -1,
+      size: 0.4 + Math.random() * 0.6,
+    })),
+  )
+
+  const [activePopups, setActivePopups] = useState([])
+  const pendingEventsRef = useRef([])
+  const bottomAlertRef = useRef(false)
+
+  useEffect(() => {
+    let animationFrame
+    let lastTimestamp
+
+    const tick = (timestamp) => {
+      if (!lastTimestamp) {
+        lastTimestamp = timestamp
+      }
+
+      const delta = Math.min((timestamp - lastTimestamp) / 1000, 0.12)
+      lastTimestamp = timestamp
+
+      setSubmarine((current) => {
+        const nextDistance = current.distanceTravelled + current.horizontalSpeed * delta
+        const acceleration = (current.targetDepth - current.depth) * 0.6
+        const nextVerticalVelocity = clamp(current.verticalVelocity + acceleration * delta, -80, 80)
+        const nextDepth = clamp(current.depth + nextVerticalVelocity * delta, MIN_DEPTH, MAX_DEPTH)
+        const energyDrain = 0.02 + Math.abs(nextVerticalVelocity) * 0.0006
+        const nearSeafloor = nextDepth > MAX_DEPTH - 10
+        const hullPenalty = nearSeafloor ? 0.5 : 0
+        if (nearSeafloor && !bottomAlertRef.current) {
+          bottomAlertRef.current = true
+          pendingEventsRef.current.push({
+            speaker: 'Lt. Ibarra',
+            message: 'Warning: keel proximity alert. Adjusting ballast to avoid scraping the ocean floor.',
+            tone: 'engineering',
+          })
+        }
+        if (!nearSeafloor && bottomAlertRef.current) {
+          bottomAlertRef.current = false
+        }
+
+        return {
+          ...current,
+          x: clamp(current.x + (current.horizontalSpeed * delta) / 2, 40, VIEWPORT_WIDTH - 120),
+          depth: nextDepth,
+          verticalVelocity: nextVerticalVelocity,
+          battery: Math.max(0, current.battery - energyDrain),
+          hullIntegrity: Math.max(0, current.hullIntegrity - hullPenalty),
+          distanceTravelled: nextDistance,
+          avoidanceClock: current.avoidanceClock + delta,
+        }
+      })
+
+      setEnemyBots((current) =>
+        current.map((bot) => {
+          let { x, depth, direction, changeTimer, speed } = bot
+          changeTimer -= delta
+          if (changeTimer <= 0) {
+            direction = Math.random() > 0.5 ? 1 : -1
+            speed = clamp(speed + (Math.random() - 0.5) * 20, 20, 55)
+            changeTimer = 3 + Math.random() * 5
+          }
+          x += direction * speed * delta
+          depth += Math.sin(timestamp / 1000 + bot.x) * 4 * delta * direction
+
+          if (x < 120) {
+            x = 120
+            direction = 1
+          }
+          if (x > VIEWPORT_WIDTH - 140) {
+            x = VIEWPORT_WIDTH - 140
+            direction = -1
+          }
+          depth = clamp(depth, MIN_DEPTH + 20, MAX_DEPTH - 20)
+
+          return {
+            ...bot,
+            x,
+            depth,
+            direction,
+            changeTimer,
+            speed,
+          }
+        }),
+      )
+
+      setFishSchools((current) =>
+        current.map((school) => {
+          let x = school.x + school.direction * school.speed * delta
+          if (x < 40) {
+            x = VIEWPORT_WIDTH - 20
+          }
+          if (x > VIEWPORT_WIDTH - 20) {
+            x = 40
+          }
+          return {
+            ...school,
+            x,
+          }
+        }),
+      )
+
+      const events = pendingEventsRef.current
+      pendingEventsRef.current = []
+      events.forEach((event) =>
+        onLog({ ...event, id: createId('log'), timestamp: new Date().toISOString() }),
+      )
+
+      animationFrame = requestAnimationFrame(tick)
+    }
+
+    animationFrame = requestAnimationFrame(tick)
+
+    return () => cancelAnimationFrame(animationFrame)
+  }, [onLog])
+
+  useEffect(() => {
+    if (!shipHasArrived && submarine.x >= VIEWPORT_WIDTH - 140) {
+      onLog({
+        id: createId('log'),
+        speaker: 'Captain Chen',
+        tone: 'command',
+        message: 'Eastern harbor in sight. Crew, prepare to surface and secure the berth.',
+        timestamp: new Date().toISOString(),
+      })
+      onArrival()
+      onAchievementUnlock('ach-arrival')
+    }
+  }, [onAchievementUnlock, onArrival, onLog, shipHasArrived, submarine.x])
+
+  useEffect(() => {
+    const achievementsToCheck = achievements.filter((achievement) => !achievement.achieved)
+    achievementsToCheck.forEach((achievement) => {
+      let achieved = false
+      if (achievement.type === 'distance' && submarine.distanceTravelled >= achievement.value) {
+        achieved = true
+      }
+      if (achievement.type === 'depth' && submarine.depth >= achievement.value) {
+        achieved = true
+      }
+      if (
+        achievement.type === 'avoidance' &&
+        submarine.avoidanceClock >= achievement.value
+      ) {
+        achieved = true
+      }
+
+      if (achieved) {
+        onAchievementUnlock(achievement.id)
+        setActivePopups((current) => [
+          ...current,
+          { id: achievement.id, label: achievement.label, timestamp: Date.now() },
+        ])
+        onLog({
+          id: createId('log'),
+          speaker: 'Mission Control',
+          tone: 'systems',
+          message: `Milestone achieved: ${achievement.label}.`,
+          timestamp: new Date().toISOString(),
+        })
+      }
+    })
+  }, [achievements, onAchievementUnlock, onLog, submarine])
+
+  useEffect(() => {
+    if (!activePopups.length) return
+    const timeout = setTimeout(() => {
+      setActivePopups((current) => current.slice(1))
+    }, 4000)
+    return () => clearTimeout(timeout)
+  }, [activePopups])
+
+  useEffect(() => {
+    const collisions = enemyBots.filter((bot) => Math.abs(bot.x - submarine.x) < 60 && Math.abs(bot.depth - submarine.depth) < 24)
+    if (collisions.length) {
+      setSubmarine((current) => ({
+        ...current,
+        hullIntegrity: Math.max(0, current.hullIntegrity - 6 * collisions.length),
+        avoidanceClock: 0,
+      }))
+      collisions.forEach((bot) => {
+        onLog({
+          id: createId('log'),
+          speaker: 'Chief Rahman',
+          tone: 'tactical',
+          message: `Bot submarine ${bot.id.replace('bot-', '#')} passed close! Helm, adjust bearing immediately.`,
+          timestamp: new Date().toISOString(),
+        })
+      })
+    }
+  }, [enemyBots, onLog, submarine.depth, submarine.x])
+
+  const depthRatio = (submarine.depth - MIN_DEPTH) / (MAX_DEPTH - MIN_DEPTH)
+  const submarineY = SURFACE_LEVEL + depthRatio * (SEA_FLOOR - SURFACE_LEVEL)
+
+  const submarineStats = [
+    { label: 'Depth', value: `${Math.round(submarine.depth)} m` },
+    {
+      label: 'Vertical velocity',
+      value: `${submarine.verticalVelocity > 0 ? 'Desc' : 'Asc'} ${Math.abs(submarine.verticalVelocity).toFixed(1)} m/s`,
+    },
+    { label: 'Forward speed', value: `${Math.round(submarine.horizontalSpeed)} kts` },
+    { label: 'Battery reserve', value: `${Math.round(submarine.battery)}%` },
+    { label: 'Hull integrity', value: `${Math.round(submarine.hullIntegrity)}%` },
+  ]
+
+  const handleCommand = (nextDepth) => {
+    const safeDepth = clamp(nextDepth, MIN_DEPTH + 5, MAX_DEPTH - 5)
+    setSubmarine((current) => ({
+      ...current,
+      targetDepth: safeDepth,
+    }))
+    onLog({
+      id: createId('log'),
+      speaker: 'Captain Chen',
+      tone: 'command',
+      message: `Set depth ${Math.round(safeDepth)} meters. Engineering, trim ballast accordingly.`,
+      timestamp: new Date().toISOString(),
+    })
+  }
+
+  const handleTrim = (direction) => {
+    setSubmarine((current) => ({
+      ...current,
+      horizontalSpeed: clamp(current.horizontalSpeed + direction * 8, 40, 110),
+    }))
+    onLog({
+      id: createId('log'),
+      speaker: 'Lt. Ibarra',
+      tone: 'engineering',
+      message:
+        direction > 0
+          ? 'Boosting propulsion coils for additional thrust. Monitoring reactor load.'
+          : 'Reducing propulsor output for a quieter profile.',
+      timestamp: new Date().toISOString(),
+    })
+  }
+
+  return (
+    <div className="game-area">
+      <AchievementTrack achievements={achievements} />
+
+      <div className="game-viewport">
+        <svg
+          className="game-canvas"
+          viewBox={`0 0 ${VIEWPORT_WIDTH} ${VIEWPORT_HEIGHT}`}
+          role="img"
+          aria-label="Submarine transit simulation"
+        >
+          <defs>
+            <linearGradient id="ocean" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#0a1c33" />
+              <stop offset="60%" stopColor="#0d2744" />
+              <stop offset="100%" stopColor="#071426" />
+            </linearGradient>
+            <linearGradient id="seafloor" x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" stopColor="#2d2f38" />
+              <stop offset="100%" stopColor="#1d1e25" />
+            </linearGradient>
+          </defs>
+
+          <rect width={VIEWPORT_WIDTH} height={VIEWPORT_HEIGHT} fill="url(#ocean)" />
+
+          <rect x="20" y={SURFACE_LEVEL - 30} width="110" height="28" fill="#131b29" rx="6" />
+          <rect
+            x={VIEWPORT_WIDTH - 140}
+            y={SURFACE_LEVEL - 30}
+            width="120"
+            height="28"
+            fill="#131b29"
+            rx="6"
+          />
+          <text x="75" y={SURFACE_LEVEL - 36} className="port-label">
+            West Port
+          </text>
+          <text x={VIEWPORT_WIDTH - 80} y={SURFACE_LEVEL - 36} className="port-label">
+            East Port
+          </text>
+
+          {enemyBots.map((bot) => {
+            const botDepthRatio = (bot.depth - MIN_DEPTH) / (MAX_DEPTH - MIN_DEPTH)
+            const botY = SURFACE_LEVEL + botDepthRatio * (SEA_FLOOR - SURFACE_LEVEL)
+            return (
+              <g key={bot.id} className="bot-submarine">
+                <ellipse cx={bot.x} cy={botY} rx="28" ry="10" fill="#6d7c8d" opacity="0.7" />
+                <rect x={bot.x - 10} y={botY - 4} width="20" height="8" fill="#55616f" />
+              </g>
+            )
+          })}
+
+          {fishSchools.map((fish) => {
+            const fishDepthRatio = (fish.depth - MIN_DEPTH) / (MAX_DEPTH - MIN_DEPTH)
+            const fishY = SURFACE_LEVEL + fishDepthRatio * (SEA_FLOOR - SURFACE_LEVEL)
+            const fishSize = 12 * fish.size
+            return (
+              <g key={fish.id} className="fish">
+                <ellipse
+                  cx={fish.x}
+                  cy={fishY}
+                  rx={fishSize}
+                  ry={fishSize * 0.4}
+                  fill="#f6b756"
+                  opacity="0.75"
+                />
+                <polygon
+                  points={`${fish.x - fishSize} ${fishY} ${fish.x - fishSize - 8 * fish.size} ${fishY - fishSize * 0.4} ${fish.x - fishSize - 8 * fish.size} ${fishY + fishSize * 0.4}`}
+                  fill="#f38f3d"
+                  opacity="0.75"
+                />
+              </g>
+            )
+          })}
+
+          <rect
+            x="0"
+            y={SEA_FLOOR}
+            width={VIEWPORT_WIDTH}
+            height={VIEWPORT_HEIGHT - SEA_FLOOR}
+            fill="url(#seafloor)"
+          />
+
+          <g className="submarine">
+            <ellipse cx={submarine.x} cy={submarineY} rx="36" ry="14" fill="#d1dde8" opacity="0.9" />
+            <rect x={submarine.x - 30} y={submarineY - 8} width="60" height="16" fill="#b4c2d0" />
+            <rect x={submarine.x - 10} y={submarineY - 20} width="20" height="12" fill="#b4c2d0" rx="3" />
+            <circle cx={submarine.x + 12} cy={submarineY} r="5" fill="#1f2d3b" />
+          </g>
+
+          {Array.from({ length: 3 }).map((_, index) => (
+            <rect
+              key={`enemy-${index}`}
+              x={220 + index * 200}
+              y={SURFACE_LEVEL - 46}
+              width="80"
+              height="16"
+              fill="#2b3447"
+            />
+          ))}
+        </svg>
+
+        <div className="stats-overlay">
+          {submarineStats.map((stat) => (
+            <div key={stat.label}>
+              <span>{stat.label}</span>
+              <strong>{stat.value}</strong>
+            </div>
+          ))}
+        </div>
+
+        <div className="control-panel">
+          <button type="button" onClick={() => handleCommand(submarine.depth - 30)}>
+            Ascend 30m
+          </button>
+          <button type="button" onClick={() => handleCommand(submarine.depth + 30)}>
+            Descend 30m
+          </button>
+          <button type="button" onClick={() => handleCommand(120)}>
+            Hold at 120m
+          </button>
+          <button type="button" onClick={() => handleTrim(-1)}>Reduce thrust</button>
+          <button type="button" onClick={() => handleTrim(1)}>Boost thrust</button>
+        </div>
+
+        {activePopups.map((popup) => (
+          <div key={popup.id} className="achievement-popup">
+            <strong>{popup.label}</strong>
+            <span>Milestone reached</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
 }
 
 function App() {
   const [crew, setCrew] = useState(initialCrew)
   const [tasks, setTasks] = useState(initialTasks)
-  const [teams, setTeams] = useState(initialTeams)
+  const [teams] = useState(initialTeams)
   const [shipLog, setShipLog] = useState(initialLog)
+  const [achievements, setAchievements] = useState(
+    achievementCatalog.map((achievement) => ({ ...achievement, achieved: false })),
+  )
   const [activeTab, setActiveTab] = useState('crew')
-  const [selectedCompartment, setSelectedCompartment] = useState('bridge')
-  const [newCrewMember, setNewCrewMember] = useState({
+  const [newCrew, setNewCrew] = useState({
     name: '',
     role: '',
     compartment: compartments[0].id,
@@ -259,7 +1014,8 @@ function App() {
     assignees: [],
     reasoning: '',
   })
-  const [newTeam, setNewTeam] = useState({ name: '', function: '', members: [] })
+  const [milestonesOpen, setMilestonesOpen] = useState(false)
+  const [hasArrived, setHasArrived] = useState(false)
 
   const crewCountByCompartment = useMemo(() => {
     return crew.reduce((acc, member) => {
@@ -275,32 +1031,41 @@ function App() {
     }, {})
   }, [crew, tasks])
 
-  const addLogEntry = ({ title, type, narrative }) => {
+  const teamsByCrew = useMemo(() => {
+    return crew.reduce((acc, member) => {
+      acc[member.id] = teams.filter((team) => team.members.includes(member.id))
+      return acc
+    }, {})
+  }, [crew, teams])
+
+  const addLogEntry = ({ speaker, message, tone }) => {
     setShipLog((current) => [
       ...current,
       {
-        id: nextId('log'),
+        id: createId('log'),
+        speaker,
+        tone,
+        message,
         timestamp: new Date().toISOString(),
-        title,
-        type,
-        narrative,
       },
     ])
   }
 
-  const handleAddCrewMember = (event) => {
+  const handleAddCrew = (event) => {
     event.preventDefault()
-    if (!newCrewMember.name.trim() || !newCrewMember.role.trim()) return
-
-    const crewId = nextId('crew')
-    const member = { id: crewId, ...newCrewMember }
-    setCrew((current) => [...current, member])
+    if (!newCrew.name.trim() || !newCrew.role.trim()) {
+      return
+    }
+    const crewMember = { id: createId('crew'), ...newCrew }
+    setCrew((current) => [...current, crewMember])
     addLogEntry({
-      title: 'Crewmember Added',
-      type: 'Crew Update',
-      narrative: `${member.name} joined as ${member.role} assigned to ${compartments.find((c) => c.id === member.compartment)?.name}. Instructions: ${member.instructions || 'awaiting detail.'}`,
+      speaker: 'Mission Control',
+      tone: 'systems',
+      message: `${crewMember.name} boarded as ${crewMember.role}. Assigned to ${
+        compartments.find((compartment) => compartment.id === crewMember.compartment)?.name
+      }.`,
     })
-    setNewCrewMember({ name: '', role: '', compartment: compartments[0].id, instructions: '' })
+    setNewCrew({ name: '', role: '', compartment: compartments[0].id, instructions: '' })
   }
 
   const handleCrewInstructionChange = (crewId, nextInstructions) => {
@@ -313,9 +1078,9 @@ function App() {
 
   const handleCrewInstructionBlur = (crewId, name, nextInstructions) => {
     addLogEntry({
-      title: 'Instruction Update',
-      type: 'Directive',
-      narrative: `${name} acknowledged new guidance: ${nextInstructions}`,
+      speaker: name,
+      tone: 'crew',
+      message: `Acknowledged updated directive: "${nextInstructions || 'Awaiting orders.'}"`,
     })
   }
 
@@ -328,9 +1093,9 @@ function App() {
     const crewMember = crew.find((member) => member.id === crewId)
     if (crewMember) {
       addLogEntry({
-        title: 'Role Adjustment',
-        type: 'Crew Update',
-        narrative: `${crewMember.name} reassigned role to ${nextRole}. Chain of command matrix updated.`,
+        speaker: crewMember.name,
+        tone: 'crew',
+        message: `Role updated to ${nextRole}. Coordinating with team leads for handoff.`,
       })
     }
   }
@@ -344,44 +1109,16 @@ function App() {
     const crewMember = crew.find((member) => member.id === crewId)
     if (crewMember) {
       addLogEntry({
-        title: 'Crew Movement',
-        type: 'Coordination',
-        narrative: `${crewMember.name} relocated to ${compartments.find((c) => c.id === nextCompartment)?.name} to reinforce workflow connectivity.`,
+        speaker: crewMember.name,
+        tone: 'crew',
+        message: `Relocating to ${
+          compartments.find((compartment) => compartment.id === nextCompartment)?.name
+        } to support operations.`,
       })
     }
   }
 
-  const handleAddTask = (event) => {
-    event.preventDefault()
-    if (!newTask.title.trim()) return
-    const task = { id: nextId('task'), status: 'Planned', ...newTask }
-    setTasks((current) => [...current, task])
-    addLogEntry({
-      title: 'Task Created',
-      type: 'Mission',
-      narrative: `${task.title} registered for ${compartments.find((c) => c.id === task.compartmentFocus)?.name}. Assigned crew: ${task.assignees
-        .map((id) => crew.find((member) => member.id === id)?.name)
-        .filter(Boolean)
-        .join(', ') || 'unassigned'}. ${task.reasoning ? `Intent: ${task.reasoning}` : ''}`,
-    })
-    setNewTask({ title: '', objective: '', compartmentFocus: compartments[0].id, assignees: [], reasoning: '' })
-  }
-
-  const updateTaskStatus = (taskId, nextStatus) => {
-    setTasks((current) =>
-      current.map((task) => (task.id === taskId ? { ...task, status: nextStatus } : task)),
-    )
-    const task = tasks.find((item) => item.id === taskId)
-    if (task) {
-      addLogEntry({
-        title: 'Task Status Updated',
-        type: 'Mission',
-        narrative: `${task.title} marked ${nextStatus}. Crew cross-check results in ship's analytics queue.`,
-      })
-    }
-  }
-
-  const toggleTaskAssignee = (crewId) => {
+  const handleToggleTaskAssignee = (crewId) => {
     setNewTask((current) => {
       const exists = current.assignees.includes(crewId)
       return {
@@ -393,542 +1130,113 @@ function App() {
     })
   }
 
-  const toggleTeamMember = (crewId) => {
-    setNewTeam((current) => {
-      const exists = current.members.includes(crewId)
-      return {
-        ...current,
-        members: exists
-          ? current.members.filter((id) => id !== crewId)
-          : [...current.members, crewId],
-      }
-    })
-  }
-
-  const handleAddTeam = (event) => {
+  const handleAddTask = (event) => {
     event.preventDefault()
-    if (!newTeam.name.trim()) return
-    const team = { id: nextId('team'), ...newTeam }
-    setTeams((current) => [...current, team])
+    if (!newTask.title.trim()) return
+    const task = { id: createId('task'), status: 'Planned', ...newTask }
+    setTasks((current) => [...current, task])
     addLogEntry({
-      title: 'Team Configuration',
-      type: 'Coordination',
-      narrative: `${team.name} established to focus on ${team.function || 'cross-discipline coordination'}. Members: ${team.members
-        .map((id) => crew.find((member) => member.id === id)?.name)
-        .filter(Boolean)
-        .join(', ') || 'pending assignment'}.`,
+      speaker: 'Captain Chen',
+      tone: 'command',
+      message: `Logged mission task "${task.title}". ${
+        task.assignees.length
+          ? `Assigned to ${task.assignees
+              .map((id) => crew.find((member) => member.id === id)?.name)
+              .filter(Boolean)
+              .join(', ')}.`
+          : 'Awaiting crew assignment.'
+      }`,
     })
-    setNewTeam({ name: '', function: '', members: [] })
+    setNewTask({ title: '', objective: '', compartmentFocus: compartments[0].id, assignees: [], reasoning: '' })
   }
 
-  const configurationGuide = useMemo(() => {
-    return compartments.map((compartment) => ({
-      ...compartment,
-      crew: crew.filter((member) => member.compartment === compartment.id),
-      tasks: tasks.filter((task) => task.compartmentFocus === compartment.id),
-    }))
-  }, [crew, tasks])
+  const handleUpdateTaskStatus = (taskId, nextStatus) => {
+    setTasks((current) =>
+      current.map((task) => (task.id === taskId ? { ...task, status: nextStatus } : task)),
+    )
+    const task = tasks.find((item) => item.id === taskId)
+    if (task) {
+      addLogEntry({
+        speaker: 'Mission Control',
+        tone: 'systems',
+        message: `Task "${task.title}" marked ${nextStatus}.`,
+      })
+    }
+  }
 
-  const selectedCompartmentDetails = configurationGuide.find(
-    (compartment) => compartment.id === selectedCompartment,
-  )
+  const handleAchievementUnlock = (achievementId) => {
+    setAchievements((current) =>
+      current.map((achievement) =>
+        achievement.id === achievementId
+          ? { ...achievement, achieved: true, achievedAt: new Date().toISOString() }
+          : achievement,
+      ),
+    )
+  }
+
+  const handleLogFromGame = (entry) => {
+    setShipLog((current) => [...current, entry])
+  }
+
+  const milestoneDrawer = milestonesOpen ? (
+    <div className="milestone-drawer" role="dialog" aria-label="Milestone descriptions">
+      <header>
+        <h2>Achievement Manifest</h2>
+        <button type="button" onClick={() => setMilestonesOpen(false)} aria-label="Close milestones">
+          Close
+        </button>
+      </header>
+      <ul>
+        {achievements.map((achievement) => (
+          <li key={achievement.id} className={achievement.achieved ? 'achieved' : undefined}>
+            <strong>{achievement.label}</strong>
+            <p>{achievement.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  ) : null
 
   return (
-    <div className="app-shell">
-      <header className="app-header">
-        <h1>Submarine Orchestration Simulator</h1>
-        <p>
-          Configure crew roles, mission tasks, and collaboration pathways while monitoring the ship's
-          live reasoning log.
-        </p>
-      </header>
+    <div className="app-layout">
+      <Sidebar
+        crew={crew}
+        tasks={tasks}
+        teams={teams}
+        activeTab={activeTab}
+        onChangeTab={setActiveTab}
+        compartments={compartments}
+        onCrewCompartmentChange={handleCrewCompartmentChange}
+        onCrewRoleChange={handleCrewRoleChange}
+        onCrewInstructionChange={handleCrewInstructionChange}
+        onCrewInstructionBlur={handleCrewInstructionBlur}
+        onUpdateTaskStatus={handleUpdateTaskStatus}
+        onToggleTaskAssignee={handleToggleTaskAssignee}
+        newTask={newTask}
+        setNewTask={setNewTask}
+        onAddTask={handleAddTask}
+        newCrew={newCrew}
+        setNewCrew={setNewCrew}
+        onAddCrew={handleAddCrew}
+        achievements={achievements}
+        onToggleMilestoneDrawer={() => setMilestonesOpen((state) => !state)}
+        isMilestoneDrawerOpen={milestonesOpen}
+        milestoneDrawer={milestoneDrawer}
+        crewCountByCompartment={crewCountByCompartment}
+        tasksByCrew={tasksByCrew}
+        teamsByCrew={teamsByCrew}
+      />
 
-      <div className="layout">
-        <SubmarineDiagram
-          compartments={compartments}
-          selectedCompartment={selectedCompartment}
-          onSelect={setSelectedCompartment}
-          crewCountByCompartment={crewCountByCompartment}
+      <div className="main-column">
+        <GameSimulation
+          onLog={handleLogFromGame}
+          achievements={achievements}
+          onAchievementUnlock={handleAchievementUnlock}
+          shipHasArrived={hasArrived}
+          onArrival={() => setHasArrived(true)}
         />
-        {selectedCompartmentDetails && (
-          <aside className="compartment-details">
-            <h2>{selectedCompartmentDetails.name}</h2>
-            <p>{selectedCompartmentDetails.description}</p>
-            <h3>Resources</h3>
-            <ul>
-              {selectedCompartmentDetails.resources.map((resource) => (
-                <li key={resource}>{resource}</li>
-              ))}
-            </ul>
-            <h3>Crew on Station</h3>
-            {selectedCompartmentDetails.crew.length ? (
-              <ul>
-                {selectedCompartmentDetails.crew.map((member) => (
-                  <li key={member.id}>{member.name}</li>
-                ))}
-              </ul>
-            ) : (
-              <p className="empty">No personnel assigned.</p>
-            )}
-            <h3>Linked Tasks</h3>
-            {selectedCompartmentDetails.tasks.length ? (
-              <ul>
-                {selectedCompartmentDetails.tasks.map((task) => (
-                  <li key={task.id}>{task.title}</li>
-                ))}
-              </ul>
-            ) : (
-              <p className="empty">No active workstreams.</p>
-            )}
-          </aside>
-        )}
+        <ShipLog entries={shipLog} />
       </div>
-
-      <TabBar activeTab={activeTab} onSelect={setActiveTab} />
-
-      <main className="tab-content">
-        {activeTab === 'crew' && (
-          <Section
-            title="Crew Manifest & Directive Editor"
-            description="Shape the available expertise and author instructions for each specialist."
-            actions={<span>{crew.length} crew onboard</span>}
-          >
-            <form className="inline-form" onSubmit={handleAddCrewMember}>
-              <div>
-                <label htmlFor="crew-name">Name</label>
-                <input
-                  id="crew-name"
-                  value={newCrewMember.name}
-                  onChange={(event) =>
-                    setNewCrewMember((state) => ({ ...state, name: event.target.value }))
-                  }
-                  placeholder="Crewmember name"
-                  required
-                />
-              </div>
-              <div>
-                <label htmlFor="crew-role">Role</label>
-                <input
-                  id="crew-role"
-                  value={newCrewMember.role}
-                  onChange={(event) =>
-                    setNewCrewMember((state) => ({ ...state, role: event.target.value }))
-                  }
-                  placeholder="e.g. Systems Analyst"
-                  required
-                />
-              </div>
-              <div>
-                <label htmlFor="crew-compartment">Station</label>
-                <select
-                  id="crew-compartment"
-                  value={newCrewMember.compartment}
-                  onChange={(event) =>
-                    setNewCrewMember((state) => ({ ...state, compartment: event.target.value }))
-                  }
-                >
-                  {compartments.map((compartment) => (
-                    <option key={compartment.id} value={compartment.id}>
-                      {compartment.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div className="wide">
-                <label htmlFor="crew-instructions">Initial Instructions</label>
-                <textarea
-                  id="crew-instructions"
-                  value={newCrewMember.instructions}
-                  onChange={(event) =>
-                    setNewCrewMember((state) => ({ ...state, instructions: event.target.value }))
-                  }
-                  placeholder="Outline their primary directives"
-                  rows={2}
-                />
-              </div>
-              <button type="submit" className="primary">
-                Add crewmember
-              </button>
-            </form>
-
-            <div className="crew-grid">
-              {crew.map((member) => (
-                <article key={member.id} className="crew-card">
-                  <header>
-                    <h3>{member.name}</h3>
-                    <div className="crew-meta">
-                      <span>
-                        Role:
-                        <input
-                          value={member.role}
-                          onChange={(event) => handleCrewRoleChange(member.id, event.target.value)}
-                        />
-                      </span>
-                      <span>
-                        Station:
-                        <select
-                          value={member.compartment}
-                          onChange={(event) =>
-                            handleCrewCompartmentChange(member.id, event.target.value)
-                          }
-                        >
-                          {compartments.map((compartment) => (
-                            <option key={compartment.id} value={compartment.id}>
-                              {compartment.name}
-                            </option>
-                          ))}
-                        </select>
-                      </span>
-                    </div>
-                  </header>
-                  <div className="crew-section">
-                    <h4>Instructions</h4>
-                    <textarea
-                      value={member.instructions}
-                      onChange={(event) =>
-                        handleCrewInstructionChange(member.id, event.target.value)
-                      }
-                      onBlur={(event) =>
-                        handleCrewInstructionBlur(member.id, member.name, event.target.value)
-                      }
-                      rows={3}
-                    />
-                  </div>
-                  <div className="crew-section">
-                    <h4>Assigned Tasks</h4>
-                    {tasksByCrew[member.id]?.length ? (
-                      <ul>
-                        {tasksByCrew[member.id].map((task) => (
-                          <li key={task.id}>{task.title}</li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="empty">No tasks assigned.</p>
-                    )}
-                  </div>
-                </article>
-              ))}
-            </div>
-          </Section>
-        )}
-
-        {activeTab === 'tasks' && (
-          <Section
-            title="Mission Taskboard"
-            description="Author operations, assign specialists, and advance mission cadence."
-            actions={<span>{tasks.length} active directives</span>}
-          >
-            <form className="inline-form" onSubmit={handleAddTask}>
-              <div>
-                <label htmlFor="task-title">Title</label>
-                <input
-                  id="task-title"
-                  value={newTask.title}
-                  onChange={(event) =>
-                    setNewTask((state) => ({ ...state, title: event.target.value }))
-                  }
-                  placeholder="Task title"
-                  required
-                />
-              </div>
-              <div className="wide">
-                <label htmlFor="task-objective">Objective</label>
-                <textarea
-                  id="task-objective"
-                  value={newTask.objective}
-                  onChange={(event) =>
-                    setNewTask((state) => ({ ...state, objective: event.target.value }))
-                  }
-                  placeholder="Describe the desired outcome"
-                  rows={2}
-                />
-              </div>
-              <div>
-                <label htmlFor="task-compartment">Primary Station</label>
-                <select
-                  id="task-compartment"
-                  value={newTask.compartmentFocus}
-                  onChange={(event) =>
-                    setNewTask((state) => ({ ...state, compartmentFocus: event.target.value }))
-                  }
-                >
-                  {compartments.map((compartment) => (
-                    <option key={compartment.id} value={compartment.id}>
-                      {compartment.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <fieldset className="assignee-picker">
-                <legend>Assign Crew</legend>
-                {crew.map((member) => (
-                  <label key={member.id}>
-                    <input
-                      type="checkbox"
-                      checked={newTask.assignees.includes(member.id)}
-                      onChange={() => toggleTaskAssignee(member.id)}
-                    />
-                    {member.name}
-                  </label>
-                ))}
-              </fieldset>
-              <div className="wide">
-                <label htmlFor="task-reasoning">Intent / Reasoning</label>
-                <textarea
-                  id="task-reasoning"
-                  value={newTask.reasoning}
-                  onChange={(event) =>
-                    setNewTask((state) => ({ ...state, reasoning: event.target.value }))
-                  }
-                  placeholder="Capture the coordination plan or risks"
-                  rows={2}
-                />
-              </div>
-              <button type="submit" className="primary">
-                Add task
-              </button>
-            </form>
-
-            <div className="task-board">
-              {tasks.map((task) => (
-                <article key={task.id} className={`task-card status-${task.status.toLowerCase()}`}>
-                  <header>
-                    <div>
-                      <h3>{task.title}</h3>
-                      <span className="status-chip">{task.status}</span>
-                    </div>
-                    <p>{task.objective}</p>
-                  </header>
-                  <dl>
-                    <div>
-                      <dt>Station</dt>
-                      <dd>{compartments.find((compartment) => compartment.id === task.compartmentFocus)?.name}</dd>
-                    </div>
-                    <div>
-                      <dt>Assignees</dt>
-                      <dd>
-                        {task.assignees
-                          .map((id) => crew.find((member) => member.id === id)?.name)
-                          .filter(Boolean)
-                          .join(', ') || 'Unassigned'}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Reasoning</dt>
-                      <dd>{task.reasoning || 'No narrative supplied yet.'}</dd>
-                    </div>
-                  </dl>
-                  <footer>
-                    {task.status !== 'Completed' && (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          updateTaskStatus(
-                            task.id,
-                            task.status === 'Planned' ? 'In Progress' : 'Completed',
-                          )
-                        }
-                      >
-                        Advance to {task.status === 'Planned' ? 'In Progress' : 'Completed'}
-                      </button>
-                    )}
-                    {task.status === 'Completed' && <span className="completed">Ready for review</span>}
-                  </footer>
-                </article>
-              ))}
-            </div>
-          </Section>
-        )}
-
-        {activeTab === 'teams' && (
-          <Section
-            title="Chain of Command Builder"
-            description="Visualize how teams overlap and how responsibilities cascade."
-            actions={<span>{teams.length} teams configured</span>}
-          >
-            <form className="inline-form" onSubmit={handleAddTeam}>
-              <div>
-                <label htmlFor="team-name">Team Name</label>
-                <input
-                  id="team-name"
-                  value={newTeam.name}
-                  onChange={(event) => setNewTeam((state) => ({ ...state, name: event.target.value }))}
-                  placeholder="e.g. Navigation Liaison"
-                  required
-                />
-              </div>
-              <div className="wide">
-                <label htmlFor="team-function">Purpose</label>
-                <textarea
-                  id="team-function"
-                  value={newTeam.function}
-                  onChange={(event) =>
-                    setNewTeam((state) => ({ ...state, function: event.target.value }))
-                  }
-                  placeholder="What coordination problem does this team solve?"
-                  rows={2}
-                />
-              </div>
-              <fieldset className="assignee-picker">
-                <legend>Attach Crew</legend>
-                {crew.map((member) => (
-                  <label key={member.id}>
-                    <input
-                      type="checkbox"
-                      checked={newTeam.members.includes(member.id)}
-                      onChange={() => toggleTeamMember(member.id)}
-                    />
-                    {member.name}
-                  </label>
-                ))}
-              </fieldset>
-              <button type="submit" className="primary">
-                Form team
-              </button>
-            </form>
-
-            <div className="team-grid">
-              {teams.map((team) => (
-                <article key={team.id} className="team-card">
-                  <header>
-                    <h3>{team.name}</h3>
-                    <p>{team.function}</p>
-                  </header>
-                  <div className="team-members">
-                    <h4>Members</h4>
-                    {team.members.length ? (
-                      <ul>
-                        {team.members.map((id) => {
-                          const member = crew.find((item) => item.id === id)
-                          return <li key={id}>{member ? member.name : 'Former crew'}</li>
-                        })}
-                      </ul>
-                    ) : (
-                      <p className="empty">No members assigned.</p>
-                    )}
-                  </div>
-                  <div className="team-matrix">
-                    <h4>Collaborative Touchpoints</h4>
-                    <table>
-                      <thead>
-                        <tr>
-                          <th>Compartment</th>
-                          <th>Supporting Tasks</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {compartments.map((compartment) => {
-                          const hasCrew = team.members.some((memberId) => {
-                            const member = crew.find((item) => item.id === memberId)
-                            return member?.compartment === compartment.id
-                          })
-                          const relatedTasks = tasks.filter((task) =>
-                            task.assignees.some((assignee) => team.members.includes(assignee)) &&
-                            task.compartmentFocus === compartment.id,
-                          )
-                          if (!hasCrew && relatedTasks.length === 0) return null
-                          return (
-                            <tr key={compartment.id}>
-                              <td>{compartment.name}</td>
-                              <td>
-                                {relatedTasks.length ? (
-                                  <ul>
-                                    {relatedTasks.map((task) => (
-                                      <li key={task.id}>{task.title}</li>
-                                    ))}
-                                  </ul>
-                                ) : (
-                                  <span className="tag">Standby support</span>
-                                )}
-                              </td>
-                            </tr>
-                          )
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
-                </article>
-              ))}
-            </div>
-          </Section>
-        )}
-
-        {activeTab === 'configuration' && (
-          <Section
-            title="Submarine Configuration Guide"
-            description="Reference compartment resources, amenities, and connected workflows."
-          >
-            <div className="configuration-grid">
-              {configurationGuide.map((compartment) => (
-                <article key={compartment.id} className="configuration-card">
-                  <header>
-                    <h3>{compartment.name}</h3>
-                    <p>{compartment.description}</p>
-                  </header>
-                  <div>
-                    <h4>Amenities & Resources</h4>
-                    <ul>
-                      {compartment.resources.map((resource) => (
-                        <li key={resource}>{resource}</li>
-                      ))}
-                    </ul>
-                  </div>
-                  <div>
-                    <h4>Assigned Crew</h4>
-                    {compartment.crew.length ? (
-                      <ul>
-                        {compartment.crew.map((member) => (
-                          <li key={member.id}>{member.name}</li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="empty">No on-duty personnel.</p>
-                    )}
-                  </div>
-                  <div>
-                    <h4>Active Tasks</h4>
-                    {compartment.tasks.length ? (
-                      <ul>
-                        {compartment.tasks.map((task) => (
-                          <li key={task.id}>{task.title}</li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="empty">No current tasking.</p>
-                    )}
-                  </div>
-                </article>
-              ))}
-            </div>
-          </Section>
-        )}
-
-        {activeTab === 'log' && (
-          <Section
-            title="Ship's Log"
-            description="All reasoning, coordination notes, and task results are recorded here for after-action analysis."
-            actions={<span>{shipLog.length} entries</span>}
-          >
-            <div className="log-list">
-              {shipLog
-                .slice()
-                .reverse()
-                .map((entry) => (
-                  <article key={entry.id} className="log-entry">
-                    <header>
-                      <h3>{entry.title}</h3>
-                      <span className="log-meta">
-                        <span className="log-type">{entry.type}</span>
-                        <time dateTime={entry.timestamp}>{formatTimestamp(entry.timestamp)}</time>
-                      </span>
-                    </header>
-                    <p>{entry.narrative}</p>
-                  </article>
-                ))}
-            </div>
-          </Section>
-        )}
-      </main>
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 :root {
-  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   line-height: 1.5;
   font-weight: 400;
   color: #f5f7ff;
@@ -20,9 +20,11 @@ body {
   margin: 0;
   min-height: 100vh;
   background: radial-gradient(circle at top, #132138, #060911 55%);
-  display: flex;
-  justify-content: center;
-  padding: 2.5rem;
+}
+
+#root {
+  width: 100%;
+  height: 100vh;
 }
 
 a {
@@ -35,8 +37,4 @@ a:hover {
 
 button {
   font: inherit;
-}
-
-#root {
-  width: min(1200px, 100%);
 }


### PR DESCRIPTION
## Summary
- reshape the simulator into a single screen with a left sidebar containing crew, task, team, and station management plus a milestone drawer
- add an animated ocean view with depth statistics, achievements, random bot submarines, and fish scaled to the vessel
- refresh styling for the sidebar, game viewport, ship log bubble, and achievement displays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d877dd3a48832e98a774cdb4f9beb2