### PR TITLE
Enhance voyage UI with collapsible panels and dynamic challenges

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,15 +12,20 @@ body {
 .app {
   display: grid;
   grid-template-columns: 320px 1fr;
-  min-height: 100vh;
+  height: 100vh;
   width: 100%;
   gap: 1.5rem;
   padding: 1.5rem;
   box-sizing: border-box;
+  overflow: hidden;
 }
 
 .app--briefing {
   overflow: hidden;
+}
+
+.app--sidebar-collapsed {
+  grid-template-columns: 120px 1fr;
 }
 
 .crew-sidebar {
@@ -29,10 +34,70 @@ body {
   border: 1px solid rgba(61, 111, 201, 0.3);
   display: flex;
   flex-direction: column;
-  padding: 1.5rem;
+  padding: 2.75rem 1.5rem 1.5rem;
   gap: 1.25rem;
   position: relative;
   z-index: 1;
+  transition: width 200ms ease, padding 200ms ease;
+}
+
+.crew-sidebar__collapse {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid rgba(113, 165, 255, 0.4);
+  background: rgba(9, 24, 44, 0.9);
+  color: #f1f6ff;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+
+.crew-sidebar__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.crew-sidebar__compact {
+  margin-top: 3.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.crew-sidebar__compact h1 {
+  font-size: 1rem;
+  text-align: center;
+}
+
+.crew-sidebar__button--icon {
+  width: 100%;
+  text-align: center;
+  padding: 0.65rem 0.75rem;
+}
+
+.crew-sidebar--collapsed {
+  padding: 2.5rem 0.75rem 1.5rem;
+  align-items: center;
+}
+
+.crew-sidebar--collapsed .crew-sidebar__status {
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: center;
+}
+
+.crew-sidebar--collapsed .crew-sidebar__list,
+.crew-sidebar--collapsed .crew-sidebar__hint,
+.crew-sidebar--collapsed .crew-sidebar__header,
+.crew-sidebar--collapsed .crew-sidebar__button:not(.crew-sidebar__button--icon) {
+  display: none;
 }
 
 .crew-sidebar__header h1 {
@@ -124,6 +189,12 @@ body {
   flex-direction: column;
   gap: 1rem;
   position: relative;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.main-panel > .map-wrapper {
+  flex: 1;
 }
 
 .top-controls {
@@ -139,13 +210,44 @@ body {
   border-radius: 20px;
   padding: 1.25rem;
   flex: 1;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 0.75rem;
 }
 
-.route-selector h2 {
+.route-selector__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.route-selector__header h2 {
   margin: 0;
   font-size: 1.1rem;
+}
+
+.route-selector__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(185, 205, 244, 0.7);
+  font-size: 0.85rem;
+}
+
+.route-selector__header button {
+  padding: 0.4rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid rgba(93, 138, 215, 0.45);
+  background: rgba(10, 24, 44, 0.92);
+  color: #f1f6ff;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+
+.route-selector__body {
+  display: grid;
+  gap: 0.75rem;
 }
 
 .route-selector__fields {
@@ -182,14 +284,71 @@ body {
   color: rgba(185, 205, 244, 0.7);
 }
 
+.route-selector--collapsed {
+  padding-bottom: 1rem;
+}
+
+.route-selector--collapsed .route-selector__body {
+  display: none;
+}
+
 .mission-controls {
   width: 260px;
   background: rgba(8, 24, 44, 0.92);
   border-radius: 20px;
   border: 1px solid rgba(70, 118, 209, 0.35);
   padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mission-controls__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.mission-controls__header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.mission-controls__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(177, 201, 244, 0.65);
+  font-size: 0.82rem;
+}
+
+.mission-controls__header button {
+  padding: 0.4rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid rgba(112, 164, 255, 0.5);
+  background: rgba(12, 30, 52, 0.92);
+  color: #f1f6ff;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+
+.mission-controls__body {
   display: grid;
   gap: 0.9rem;
+}
+
+.mission-controls__summary {
+  font-size: 0.85rem;
+  color: rgba(189, 209, 247, 0.75);
+}
+
+.mission-controls--collapsed {
+  gap: 0.5rem;
+}
+
+.mission-controls--collapsed .mission-controls__body {
+  display: none;
 }
 
 .mission-status span {
@@ -240,8 +399,9 @@ body {
   padding: 1.25rem;
   display: grid;
   gap: 1rem;
-  max-height: 260px;
+  max-height: min(32vh, 260px);
   overflow-y: auto;
+  flex: 0 0 auto;
 }
 
 .ship-log h2 {
@@ -299,12 +459,19 @@ body {
 }
 
 .map-viewport {
-  flex: 1;
   width: 100%;
+  height: 100%;
   border-radius: 24px;
   border: 1px solid rgba(74, 122, 217, 0.45);
   background: #04101e;
   box-shadow: inset 0 0 40px rgba(6, 28, 54, 0.8);
+}
+
+.map-wrapper {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
 }
 
 .world-outline polygon {
@@ -334,14 +501,89 @@ body {
   text-shadow: 0 0 6px rgba(0, 0, 0, 0.75);
 }
 
-.submarine circle {
-  fill: #ef476f;
+.submarine ellipse {
+  fill: rgba(239, 71, 111, 0.85);
   stroke: rgba(239, 71, 111, 0.65);
   stroke-width: 3;
 }
 
+.submarine rect {
+  fill: rgba(255, 255, 255, 0.8);
+  stroke: rgba(239, 71, 111, 0.65);
+  stroke-width: 2;
+}
+
 .submarine polygon {
-  fill: rgba(239, 71, 111, 0.8);
+  fill: rgba(255, 152, 166, 0.85);
+  stroke: rgba(239, 71, 111, 0.65);
+  stroke-width: 2;
+}
+
+.submarine circle {
+  fill: rgba(12, 28, 51, 0.9);
+  stroke: rgba(239, 71, 111, 0.65);
+  stroke-width: 2;
+}
+
+.map-obstacle circle {
+  stroke: rgba(7, 17, 32, 0.8);
+  stroke-width: 3;
+}
+
+.map-obstacle path {
+  stroke-width: 3;
+  stroke-linecap: round;
+}
+
+.map-obstacle text {
+  fill: #ffffff;
+  font-size: 0.75rem;
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.7);
+}
+
+.map-obstacle--resolved {
+  opacity: 0.4;
+}
+
+.obstacle-console {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  background: rgba(5, 15, 30, 0.82);
+  border: 1px solid rgba(89, 138, 223, 0.35);
+  box-shadow: 0 8px 22px rgba(2, 10, 24, 0.45);
+}
+
+.obstacle-console strong {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(189, 210, 249, 0.8);
+}
+
+.obstacle-console button {
+  padding: 0.45rem 0.6rem;
+  border-radius: 10px;
+  border: 1px solid rgba(112, 164, 255, 0.5);
+  background: rgba(12, 32, 58, 0.9);
+  color: #f3f7ff;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.obstacle-console button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.obstacle-console[aria-hidden='true'] {
+  opacity: 0.35;
+  pointer-events: none;
 }
 
 .port-labels text {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import './App.css'
 import { crew as crewManifest } from './data/crew.js'
 import { ports } from './data/ports.js'
@@ -9,6 +9,97 @@ import { requestCrewThought } from './services/openaiResponses.js'
 const MAP_WIDTH = 1280
 const MAP_HEIGHT = 720
 const TIME_SCALE = Number(import.meta.env.VITE_SIMULATION_TIME_SCALE ?? 1)
+
+const OBSTACLE_TYPES = {
+  battleship: {
+    label: 'Battleship screen',
+    description: 'Surface fleet interdiction detected ahead of the cable corridor.',
+    iconColor: '#f78c6b',
+    analystReport: 'Surface contact designated as hostile destroyer screen. Recommend veer five degrees port and drop to 180m.',
+    captainDirective:
+      'Captain Mira Chen: Navigation, execute the port veer and keep ballast trimmed. Intel, maintain sonar picture every thirty seconds.',
+    operationsFollowUp:
+      'Operations: Combat systems shifting to passive sweep, all departments report ready to counter decoy drops.',
+    navigatorAction: 'Navigation: Plotting a slow arc to port and pulsing lateral thrusters to skirt the destroyer screen.',
+  },
+  thermalVent: {
+    label: 'Thermal vent surge',
+    description: 'Unexpected hydrothermal vent activity threatens hull stability.',
+    iconColor: '#ffd166',
+    analystReport:
+      "Intel: Thermal bloom rising fast — recommending we descend ten meters and throttle to seventy percent until turbulence subsides.",
+    captainDirective:
+      'Captain Mira Chen: Engineering, prioritize coolant to the starboard exchanger. Navigation, hold present course and depth change.',
+    operationsFollowUp:
+      'Operations: Damage control parties on standby, routing auxiliary power to trim pumps for rapid response.',
+    navigatorAction: 'Navigation: Dropping ten meters and stabilizing pitch to ride out the thermal plume.',
+  },
+  debrisField: {
+    label: 'Debris field',
+    description: 'Fragmented cable sheathing and trawler debris crowd the channel.',
+    iconColor: '#06d6a0',
+    analystReport:
+      'Intel: Identifying composite shards; advising micro-adjustments to avoid abrasion on the dorsal sensor mast.',
+    captainDirective:
+      'Captain Mira Chen: Navigator, plot a slalom along the safe nodes and keep comms tethered to maintenance crew.',
+    operationsFollowUp:
+      'Operations: Launching tether drones to mark the debris line; crews ready to secure any recovered sections.',
+    navigatorAction: 'Navigation: Threading micro-waypoints through the debris corridor while safeguarding the dorsal array.',
+  },
+}
+
+const HEARTBEAT_TASKS = [
+  {
+    crewId: 'intel',
+    buildTranscript: ({ crewMember }) =>
+      `${crewMember.name}: Sensor fusion cycle green; hazards queued for bridge review.`,
+    buildThoughts: ({ telemetry }) => [
+      'Refreshing maritime intelligence overlays.',
+      `Monitoring corridor at ${(telemetry.progress * 100).toFixed(0)}% completion.`,
+      'Scheduling next threat broadcast to the command deck.',
+    ],
+  },
+  {
+    crewId: 'captain',
+    buildTranscript: ({ crewMember }) =>
+      `${crewMember.name}: Maintain cadence and report deviations immediately.`,
+    buildThoughts: ({ telemetry }) => [
+      `Reviewing bridge status at T+${formatTime(telemetry.elapsedMs)}.`,
+      'Confirming navigation offsets align with mission plan.',
+      'Coordinating readiness posture with operations.',
+    ],
+  },
+  {
+    crewId: 'engineer',
+    buildTranscript: ({ crewMember }) =>
+      `${crewMember.name}: Thermal envelopes steady; rerouting spare capacity to maneuvering.`,
+    buildThoughts: () => [
+      'Sweeping diagnostics across propulsion pods.',
+      'Balancing reactor output with ballast adjustments.',
+      'Logging engineering status to systems console.',
+    ],
+  },
+  {
+    crewId: 'navigator',
+    buildTranscript: ({ crewMember }) =>
+      `${crewMember.name}: Waypoints locked — autopilot gliding along the cable grade.`,
+    buildThoughts: ({ telemetry }) => [
+      `Interpolating bathymetry at ${(telemetry.progress * 100).toFixed(1)}% of route.`,
+      'Checking helm inputs for micro-corrections.',
+      'Synchronizing updates with mission command.',
+    ],
+  },
+  {
+    crewId: 'operations',
+    buildTranscript: ({ crewMember }) =>
+      `${crewMember.name}: Crew rotations steady; obstacle drills ready on short notice.`,
+    buildThoughts: () => [
+      'Auditing compartment readiness reports.',
+      'Coordinating with engineering for contingency rehearsals.',
+      'Updating ship log tasks for next rotation.',
+    ],
+  },
+]
 
 function createId(prefix) {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -40,31 +131,66 @@ function groupCrewByRole(crew) {
   }, new Map())
 }
 
-function CrewSidebar({ crewSummary, onOpenBriefing, isPaused, canResume }) {
+function CrewSidebar({
+  crewSummary,
+  onOpenBriefing,
+  isPaused,
+  canResume,
+  isCollapsed,
+  onToggleCollapse,
+}) {
   return (
-    <aside className="crew-sidebar" aria-label="Crew summary sidebar">
-      <header className="crew-sidebar__header">
-        <h1>Global Cable Traverse</h1>
-        <p>Monitor crew allotments while the submarine follows intercontinental fiber routes.</p>
-      </header>
-      <ul className="crew-sidebar__list">
-        {crewSummary.map(({ role, units }) => (
-          <li key={role}>
-            <span className="crew-role">{role}</span>
-            <span className="crew-units">{units} units</span>
-          </li>
-        ))}
-      </ul>
-      <button type="button" className="crew-sidebar__button" onClick={onOpenBriefing}>
-        View crew instructions
+    <aside
+      className={isCollapsed ? 'crew-sidebar crew-sidebar--collapsed' : 'crew-sidebar'}
+      aria-label="Crew summary sidebar"
+    >
+      <button
+        type="button"
+        className="crew-sidebar__collapse"
+        onClick={onToggleCollapse}
+        aria-expanded={!isCollapsed}
+        aria-controls={isCollapsed ? undefined : 'crew-sidebar-content'}
+      >
+        {isCollapsed ? 'Expand' : 'Collapse'}
       </button>
-      <p className="crew-sidebar__hint">
-        Expanding the crew briefing pauses the voyage so you can adjust directives and alliances.
-      </p>
       <div className="crew-sidebar__status">
         <span className={isPaused ? 'status-dot paused' : 'status-dot running'} aria-hidden="true" />
         <span>{isPaused ? (canResume ? 'Paused' : 'Awaiting launch') : 'Underway'}</span>
       </div>
+      {isCollapsed ? (
+        <div className="crew-sidebar__compact">
+          <h1>Global Cable Traverse</h1>
+          <button
+            type="button"
+            className="crew-sidebar__button crew-sidebar__button--icon"
+            onClick={onOpenBriefing}
+            aria-label="Open crew briefing"
+          >
+            Briefing
+          </button>
+        </div>
+      ) : (
+        <div id="crew-sidebar-content" className="crew-sidebar__content">
+          <header className="crew-sidebar__header">
+            <h1>Global Cable Traverse</h1>
+            <p>Monitor crew allotments while the submarine follows intercontinental fiber routes.</p>
+          </header>
+          <ul className="crew-sidebar__list">
+            {crewSummary.map(({ role, units }) => (
+              <li key={role}>
+                <span className="crew-role">{role}</span>
+                <span className="crew-units">{units} units</span>
+              </li>
+            ))}
+          </ul>
+          <button type="button" className="crew-sidebar__button" onClick={onOpenBriefing}>
+            View crew instructions
+          </button>
+          <p className="crew-sidebar__hint">
+            Expanding the crew briefing pauses the voyage so you can adjust directives and alliances.
+          </p>
+        </div>
+      )}
     </aside>
   )
 }
@@ -176,54 +302,131 @@ function RouteSelector({
   availableOrigins,
   availableDestinations,
   currentRoute,
+  isLocked,
+  isCollapsed,
+  onToggleCollapse,
 }) {
   return (
-    <section className="route-selector" aria-label="Route selection">
-      <h2>Route Configuration</h2>
-      <div className="route-selector__fields">
-        <label htmlFor="origin-port">Origin port</label>
-        <select id="origin-port" value={origin ?? ''} onChange={(event) => onOriginChange(event.target.value || null)}>
-          <option value="">Select origin</option>
-          {availableOrigins.map((port) => (
-            <option key={port.id} value={port.id}>
-              {port.name} — {port.country}
-            </option>
-          ))}
-        </select>
-      </div>
-      <div className="route-selector__fields">
-        <label htmlFor="destination-port">Destination port</label>
-        <select
-          id="destination-port"
-          value={destination ?? ''}
-          onChange={(event) => onDestinationChange(event.target.value || null)}
-          disabled={!origin}
-        >
-          <option value="">Select destination</option>
-          {availableDestinations.map((port) => (
-            <option key={port.id} value={port.id}>
-              {port.name} — {port.country}
-            </option>
-          ))}
-        </select>
-      </div>
-      {currentRoute ? (
-        <div className="route-selector__meta">
-          <p>
-            Cable system: <strong>{currentRoute.cable}</strong>
-          </p>
-          <p>
-            Estimated traversal: <strong>{currentRoute.travelMinutes} minutes</strong>
-          </p>
+    <section className={isCollapsed ? 'route-selector route-selector--collapsed' : 'route-selector'} aria-label="Route selection">
+      <header className="route-selector__header">
+        <div>
+          <h2>Route Configuration</h2>
+          <p>Define the operational corridor and cable partner.</p>
         </div>
-      ) : (
-        <p className="route-selector__hint">Select a supported origin and destination to review the submarine path.</p>
+        <button type="button" onClick={onToggleCollapse} aria-expanded={!isCollapsed}>
+          {isCollapsed ? 'Expand' : 'Collapse'}
+        </button>
+      </header>
+      {isCollapsed ? null : (
+        <div className="route-selector__body">
+          <div className="route-selector__fields">
+            <label htmlFor="origin-port">Origin port</label>
+            <select
+              id="origin-port"
+              value={origin ?? ''}
+              onChange={(event) => onOriginChange(event.target.value || null)}
+              disabled={isLocked}
+            >
+              <option value="">Select origin</option>
+              {availableOrigins.map((port) => (
+                <option key={port.id} value={port.id}>
+                  {port.name} — {port.country}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="route-selector__fields">
+            <label htmlFor="destination-port">Destination port</label>
+            <select
+              id="destination-port"
+              value={destination ?? ''}
+              onChange={(event) => onDestinationChange(event.target.value || null)}
+              disabled={!origin || isLocked}
+            >
+              <option value="">Select destination</option>
+              {availableDestinations.map((port) => (
+                <option key={port.id} value={port.id}>
+                  {port.name} — {port.country}
+                </option>
+              ))}
+            </select>
+          </div>
+          {currentRoute ? (
+            <div className="route-selector__meta">
+              <p>
+                Cable system: <strong>{currentRoute.cable}</strong>
+              </p>
+              <p>
+                Estimated traversal: <strong>{currentRoute.travelMinutes} minutes</strong>
+              </p>
+            </div>
+          ) : (
+            <p className="route-selector__hint">
+              Select a supported origin and destination to review the submarine path.
+            </p>
+          )}
+        </div>
       )}
     </section>
   )
 }
 
-function MapViewport({ route, progress, milestones, submarinePosition }) {
+function MissionControls({
+  elapsedMs,
+  onStart,
+  onPauseToggle,
+  onRestart,
+  canStart,
+  isRunning,
+  isPaused,
+  isCollapsed,
+  onToggleCollapse,
+}) {
+  return (
+    <section className={isCollapsed ? 'mission-controls mission-controls--collapsed' : 'mission-controls'}>
+      <header className="mission-controls__header">
+        <div>
+          <h2>Mission Flow</h2>
+          <p>Coordinate launch authority and voyage tempo.</p>
+        </div>
+        <button type="button" onClick={onToggleCollapse} aria-expanded={!isCollapsed}>
+          {isCollapsed ? 'Expand' : 'Collapse'}
+        </button>
+      </header>
+      {isCollapsed ? (
+        <div className="mission-controls__summary">Elapsed {formatTime(elapsedMs)}</div>
+      ) : (
+        <div className="mission-controls__body">
+          <div className="mission-status">
+            <span>Elapsed</span>
+            <strong>{formatTime(elapsedMs)}</strong>
+          </div>
+          <div className="mission-buttons">
+            <button type="button" onClick={onStart} disabled={!canStart}>
+              Launch voyage
+            </button>
+            <button type="button" onClick={onPauseToggle} disabled={!isRunning}>
+              {isPaused ? 'Resume' : 'Pause'}
+            </button>
+            <button type="button" onClick={onRestart}>
+              Restart
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function MapViewport({
+  route,
+  progress,
+  milestones,
+  submarinePosition,
+  obstacles,
+  onAddObstacle,
+  isRunning,
+}) {
   const projectedRoute = useMemo(() => {
     if (!route) return []
     return route.path.map((point) => projectPoint(point))
@@ -249,61 +452,117 @@ function MapViewport({ route, progress, milestones, submarinePosition }) {
     })
   }, [route, milestones])
 
+  const projectedObstacles = useMemo(() => {
+    if (!route) return []
+    return obstacles.map((obstacle) => {
+      if (!route.path.length) return null
+      const totalSegments = route.path.length - 1
+      const targetDistance = obstacle.ratio * totalSegments
+      const baseIndex = Math.min(Math.floor(targetDistance), totalSegments - 1)
+      const segmentRatio = targetDistance - baseIndex
+      const start = route.path[baseIndex]
+      const end = route.path[baseIndex + 1]
+      const latitude = start.latitude + (end.latitude - start.latitude) * segmentRatio
+      const longitude = start.longitude + (end.longitude - start.longitude) * segmentRatio
+      return {
+        id: obstacle.id,
+        type: obstacle.type,
+        coordinates: projectPoint({ latitude, longitude }),
+        resolved: obstacle.resolved,
+      }
+    })
+  }, [route, obstacles])
+
   return (
-    <svg
-      className="map-viewport"
-      viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
-      role="img"
-      aria-label="Global submarine cable voyage"
-    >
-      <defs>
-        <linearGradient id="ocean" x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="0%" stopColor="#082032" />
-          <stop offset="100%" stopColor="#0c4160" />
-        </linearGradient>
-      </defs>
-      <rect width={MAP_WIDTH} height={MAP_HEIGHT} fill="url(#ocean)" />
-      <g className="world-outline">
-        {worldPolygons.map((feature) => (
-          <polygon
-            key={feature.id}
-            points={feature.coordinates.map(([lon, lat]) => projectPoint({ latitude: lat, longitude: lon }).join(',')).join(' ')}
-          />
+    <div className="map-wrapper">
+      <svg
+        className="map-viewport"
+        viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
+        role="img"
+        aria-label="Global submarine cable voyage"
+        preserveAspectRatio="xMidYMid meet"
+      >
+        <defs>
+          <linearGradient id="ocean" x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" stopColor="#082032" />
+            <stop offset="100%" stopColor="#0c4160" />
+          </linearGradient>
+        </defs>
+        <rect width={MAP_WIDTH} height={MAP_HEIGHT} fill="url(#ocean)" />
+        <g className="world-outline">
+          {worldPolygons.map((feature) => (
+            <polygon
+              key={feature.id}
+              points={feature.coordinates.map(([lon, lat]) => projectPoint({ latitude: lat, longitude: lon }).join(',')).join(' ')}
+            />
+          ))}
+        </g>
+        {projectedRoute.length ? (
+          <g className="route-path">
+            <polyline points={projectedRoute.map(([x, y]) => `${x},${y}`).join(' ')} />
+            {projectedMilestones.map((milestone) =>
+              milestone ? (
+                <g key={milestone.id} className="route-milestone" transform={`translate(${milestone.coordinates[0]}, ${milestone.coordinates[1]})`}>
+                  <circle r="8" />
+                  <text x="12" y="4">{milestone.label}</text>
+                </g>
+              ) : null,
+            )}
+          </g>
+        ) : null}
+        {projectedObstacles.map((obstacle) => {
+          if (!obstacle) return null
+          const config = OBSTACLE_TYPES[obstacle.type] ?? {}
+          return (
+            <g
+              key={obstacle.id}
+              className={obstacle.resolved ? 'map-obstacle map-obstacle--resolved' : 'map-obstacle'}
+              transform={`translate(${obstacle.coordinates[0]}, ${obstacle.coordinates[1]})`}
+            >
+              <circle r="14" fill={config.iconColor ?? '#ffffff'} />
+              <path d="M-10,0 L10,0 M0,-10 L0,10" stroke={config.iconColor ?? '#ffffff'} />
+              <text x="0" y="26" textAnchor="middle">
+                {config.label ?? 'Hazard'}
+              </text>
+            </g>
+          )
+        })}
+        {submarinePosition ? (
+          <g className="submarine" transform={`translate(${submarinePosition[0]}, ${submarinePosition[1]})`}>
+            <ellipse cx="0" cy="0" rx="26" ry="12" />
+            <rect x="-8" y="-14" width="16" height="10" rx="4" />
+            <polygon points="26,0 16,-8 16,8" />
+            <circle cx="-14" cy="0" r="4" />
+          </g>
+        ) : null}
+        {route ? (
+          <g className="port-labels">
+            <text {...anchorText(resolvePort(route.origin))}>
+              {resolvePort(route.origin).name}
+            </text>
+            <text {...anchorText(resolvePort(route.destination))}>
+              {resolvePort(route.destination).name}
+            </text>
+          </g>
+        ) : null}
+        <text className="progress-indicator" x={MAP_WIDTH - 24} y={MAP_HEIGHT - 24} textAnchor="end">
+          {Math.round(progress * 100)}% complete
+        </text>
+      </svg>
+      <div className="obstacle-console" aria-hidden={!isRunning}>
+        <strong>Inject challenges</strong>
+        {Object.entries(OBSTACLE_TYPES).map(([type, config]) => (
+          <button
+            key={type}
+            type="button"
+            onClick={() => onAddObstacle(type)}
+            disabled={!route || !isRunning}
+          >
+            {config.label}
+          </button>
         ))}
-      </g>
-      {projectedRoute.length ? (
-        <g className="route-path">
-          <polyline points={projectedRoute.map(([x, y]) => `${x},${y}`).join(' ')} />
-          {projectedMilestones.map((milestone) =>
-            milestone ? (
-              <g key={milestone.id} className="route-milestone" transform={`translate(${milestone.coordinates[0]}, ${milestone.coordinates[1]})`}>
-                <circle r="8" />
-                <text x="12" y="4">{milestone.label}</text>
-              </g>
-            ) : null,
-          )}
-        </g>
-      ) : null}
-      {submarinePosition ? (
-        <g className="submarine" transform={`translate(${submarinePosition[0]}, ${submarinePosition[1]})`}>
-          <circle r="10" />
-          <polygon points="-18,0 -4,-6 -4,6" />
-        </g>
-      ) : null}
-      {route ? (
-        <g className="port-labels">
-          <text {...anchorText(resolvePort(route.origin))}>
-            {resolvePort(route.origin).name}
-          </text>
-          <text {...anchorText(resolvePort(route.destination))}>
-            {resolvePort(route.destination).name}
-          </text>
-        </g>
-      ) : null}
-      <text className="progress-indicator" x={MAP_WIDTH - 24} y={MAP_HEIGHT - 24} textAnchor="end">
-        {Math.round(progress * 100)}% complete
-      </text>
-    </svg>
+      </div>
+    </div>
   )
 }
 
@@ -327,13 +586,22 @@ function App() {
   const [isRunning, setIsRunning] = useState(false)
   const [isPaused, setIsPaused] = useState(true)
   const [isCrewExpanded, setIsCrewExpanded] = useState(false)
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
+  const [isRouteCollapsed, setIsRouteCollapsed] = useState(false)
+  const [isMissionCollapsed, setIsMissionCollapsed] = useState(false)
+  const [hasLaunched, setHasLaunched] = useState(false)
   const resumeAfterOverlayRef = useRef(false)
   const [logEntries, setLogEntries] = useState([])
   const [triggeredMilestones, setTriggeredMilestones] = useState([])
+  const [obstacles, setObstacles] = useState([])
   const previousRouteKeyRef = useRef('none')
 
   const animationFrameRef = useRef(null)
   const lastTickRef = useRef(null)
+  const obstacleTimersRef = useRef(new Set())
+  const heartbeatIntervalRef = useRef(null)
+  const crewHeartbeatIndexRef = useRef(0)
+  const latestTelemetryRef = useRef({ progress: 0, elapsedMs: 0 })
 
   const currentRoute = useMemo(() => {
     if (!origin || !destination) return null
@@ -341,6 +609,21 @@ function App() {
   }, [origin, destination])
 
   const routeKey = currentRoute ? `${currentRoute.origin}-${currentRoute.destination}` : 'none'
+
+  const pushLogEntry = useCallback((entry) => {
+    setLogEntries((entries) => [entry, ...entries])
+  }, [])
+
+  const scheduleLogEntry = useCallback(
+    (delay, factory) => {
+      const timeoutId = setTimeout(() => {
+        obstacleTimersRef.current.delete(timeoutId)
+        pushLogEntry(factory())
+      }, delay)
+      obstacleTimersRef.current.add(timeoutId)
+    },
+    [pushLogEntry],
+  )
 
   useEffect(() => {
     if (previousRouteKeyRef.current !== routeKey) {
@@ -350,9 +633,27 @@ function App() {
       setIsPaused(true)
       setTriggeredMilestones([])
       setLogEntries([])
+      setHasLaunched(false)
+      setObstacles([])
+      obstacleTimersRef.current.forEach((timeoutId) => clearTimeout(timeoutId))
+      obstacleTimersRef.current.clear()
+      if (heartbeatIntervalRef.current) {
+        clearInterval(heartbeatIntervalRef.current)
+        heartbeatIntervalRef.current = null
+      }
+      crewHeartbeatIndexRef.current = 0
       previousRouteKeyRef.current = routeKey
     }
   }, [routeKey])
+
+  useEffect(() => () => {
+    obstacleTimersRef.current.forEach((timeoutId) => clearTimeout(timeoutId))
+    obstacleTimersRef.current.clear()
+    if (heartbeatIntervalRef.current) {
+      clearInterval(heartbeatIntervalRef.current)
+      heartbeatIntervalRef.current = null
+    }
+  }, [])
 
   const crewSummary = useMemo(() => {
     const grouped = groupCrewByRole(crewState)
@@ -371,6 +672,10 @@ function App() {
     )
     return ports.filter((port) => supportedDestinations.has(port.id))
   }, [origin])
+
+  useEffect(() => {
+    latestTelemetryRef.current = { progress, elapsedMs }
+  }, [progress, elapsedMs])
 
   const submarinePosition = useMemo(() => {
     if (!currentRoute) return null
@@ -435,6 +740,47 @@ function App() {
       }
     }
   }, [isRunning, isPaused, currentRoute])
+
+  useEffect(() => {
+    if (!obstacles.some((obstacle) => !obstacle.resolved)) return
+    const resolvedNow = []
+    setObstacles((current) => {
+      let changed = false
+      const next = current.map((obstacle) => {
+        const clearanceThreshold = Math.min(obstacle.ratio + 0.04, 0.98)
+        if (!obstacle.resolved && progress >= clearanceThreshold) {
+          resolvedNow.push(obstacle)
+          changed = true
+          return { ...obstacle, resolved: true }
+        }
+        return obstacle
+      })
+      return changed ? next : current
+    })
+
+    resolvedNow.forEach((obstacle) => {
+      const config = OBSTACLE_TYPES[obstacle.type]
+      if (!config) return
+      pushLogEntry({
+        id: createId('log'),
+        type: 'crew',
+        author: 'Chief Ava Rahman',
+        role: 'Engineering',
+        transcript: `${config.label} cleared. Engineering returning propulsion mix to cruise settings.`,
+        chainOfThought: [
+          'Confirming structural sensors back within norms.',
+          'Rebalancing reactor output to standard cruise.',
+          'Logging clearance with operations.',
+        ],
+        timestamp: new Date().toISOString(),
+      })
+      const cleanupId = setTimeout(() => {
+        setObstacles((current) => current.filter((item) => item.id !== obstacle.id))
+        obstacleTimersRef.current.delete(cleanupId)
+      }, 4500)
+      obstacleTimersRef.current.add(cleanupId)
+    })
+  }, [progress, obstacles, pushLogEntry])
 
   useEffect(() => {
     if (!currentRoute) return
@@ -516,6 +862,9 @@ function App() {
     ])
     setIsRunning(true)
     setIsPaused(false)
+    setHasLaunched(true)
+    setObstacles([])
+    crewHeartbeatIndexRef.current = 0
   }
 
   const handlePauseToggle = () => {
@@ -530,6 +879,15 @@ function App() {
     setIsPaused(true)
     setTriggeredMilestones([])
     setLogEntries([])
+    setHasLaunched(false)
+    setObstacles([])
+    obstacleTimersRef.current.forEach((timeoutId) => clearTimeout(timeoutId))
+    obstacleTimersRef.current.clear()
+    if (heartbeatIntervalRef.current) {
+      clearInterval(heartbeatIntervalRef.current)
+      heartbeatIntervalRef.current = null
+    }
+    crewHeartbeatIndexRef.current = 0
   }
 
   const openCrewBriefing = () => {
@@ -554,13 +912,132 @@ function App() {
     setCrewState((state) => state.map((member) => (member.id === crewId ? { ...member, alliances } : member)))
   }
 
+  const addObstacle = useCallback(
+    (type) => {
+      if (!currentRoute) return
+      const config = OBSTACLE_TYPES[type]
+      if (!config) return
+      const ratio = Math.min(progress + 0.08, 0.92)
+      const obstacle = { id: createId('obstacle'), type, ratio, resolved: false }
+      setObstacles((state) => [...state, obstacle])
+      const timestamp = new Date().toISOString()
+      pushLogEntry({
+        id: createId('log'),
+        type: 'system',
+        author: 'Mission Control',
+        transcript: `${config.label}: ${config.description}`,
+        chainOfThought: [],
+        timestamp,
+      })
+      scheduleLogEntry(400, () => ({
+        id: createId('log'),
+        type: 'crew',
+        author: "Analyst Priya N'Dour",
+        role: 'Intelligence',
+        transcript: config.analystReport,
+        chainOfThought: [
+          'Refreshing sensor fusion loop for obstacle classification.',
+          `Estimating clearance vector for ${config.label.toLowerCase()}.`,
+          'Relaying recommendations to the bridge team.',
+        ],
+        timestamp: new Date().toISOString(),
+      }))
+      scheduleLogEntry(950, () => ({
+        id: createId('log'),
+        type: 'crew',
+        author: 'Captain Mira Chen',
+        role: 'Mission Command',
+        transcript: config.captainDirective,
+        chainOfThought: [
+          'Reviewing analyst summary and navigational offsets.',
+          'Coordinating ballast and propulsion directives.',
+          'Tasking operations for contingency readiness.',
+        ],
+        timestamp: new Date().toISOString(),
+      }))
+      scheduleLogEntry(1500, () => ({
+        id: createId('log'),
+        type: 'crew',
+        author: 'Warrant Jorge Ibarra',
+        role: 'Operations Control',
+        transcript: config.operationsFollowUp,
+        chainOfThought: [
+          'Paging response teams across compartments.',
+          'Updating systems checklist for evolving hazard.',
+          'Confirming crew execution timelines.',
+        ],
+        timestamp: new Date().toISOString(),
+      }))
+      scheduleLogEntry(2000, () => ({
+        id: createId('log'),
+        type: 'crew',
+        author: 'Lieutenant Theo Park',
+        role: 'Navigation',
+        transcript: config.navigatorAction,
+        chainOfThought: [
+          'Projecting detour across plotted bathymetry.',
+          'Feeding updated waypoints to helm control.',
+          'Verifying clearance margins on cable segment.',
+        ],
+        timestamp: new Date().toISOString(),
+      }))
+    },
+    [currentRoute, progress, pushLogEntry, scheduleLogEntry],
+  )
+
+  useEffect(() => {
+    if (!isRunning || isPaused) {
+      if (heartbeatIntervalRef.current) {
+        clearInterval(heartbeatIntervalRef.current)
+        heartbeatIntervalRef.current = null
+      }
+      return undefined
+    }
+
+    const interval = setInterval(() => {
+      const sequence = HEARTBEAT_TASKS[crewHeartbeatIndexRef.current % HEARTBEAT_TASKS.length]
+      crewHeartbeatIndexRef.current += 1
+      const crewMember = crewState.find((member) => member.id === sequence.crewId)
+      if (!crewMember) return
+      const telemetry = latestTelemetryRef.current
+      pushLogEntry({
+        id: createId('log'),
+        type: 'crew',
+        author: crewMember.name,
+        role: crewMember.role,
+        transcript: sequence.buildTranscript({ crewMember, telemetry }),
+        chainOfThought: sequence.buildThoughts({ crewMember, telemetry }),
+        timestamp: new Date().toISOString(),
+      })
+    }, Math.max(4000, 12000 / Math.max(TIME_SCALE, 0.1)))
+
+    heartbeatIntervalRef.current = interval
+
+    return () => {
+      clearInterval(interval)
+      heartbeatIntervalRef.current = null
+    }
+  }, [isRunning, isPaused, crewState, pushLogEntry])
+
   return (
-    <div className={isCrewExpanded ? 'app app--briefing' : 'app'}>
+    <div
+      className={
+        [
+          'app',
+          isCrewExpanded ? 'app--briefing' : null,
+          isSidebarCollapsed ? 'app--sidebar-collapsed' : null,
+        ]
+          .filter(Boolean)
+          .join(' ')
+      }
+    >
       <CrewSidebar
         crewSummary={crewSummary}
         onOpenBriefing={openCrewBriefing}
         isPaused={isPaused}
         canResume={isRunning}
+        isCollapsed={isSidebarCollapsed}
+        onToggleCollapse={() => setIsSidebarCollapsed((state) => !state)}
       />
       <main className="main-panel">
         <div className="top-controls">
@@ -580,24 +1057,21 @@ function App() {
             availableOrigins={availableOrigins}
             availableDestinations={availableDestinations}
             currentRoute={currentRoute}
+            isLocked={hasLaunched}
+            isCollapsed={isRouteCollapsed}
+            onToggleCollapse={() => setIsRouteCollapsed((state) => !state)}
           />
-          <div className="mission-controls">
-            <div className="mission-status">
-              <span>Elapsed</span>
-              <strong>{formatTime(elapsedMs)}</strong>
-            </div>
-            <div className="mission-buttons">
-              <button type="button" onClick={handleStart} disabled={!canStart}>
-                Launch voyage
-              </button>
-              <button type="button" onClick={handlePauseToggle} disabled={!isRunning}>
-                {isPaused ? 'Resume' : 'Pause'}
-              </button>
-              <button type="button" onClick={handleRestart}>
-                Restart
-              </button>
-            </div>
-          </div>
+          <MissionControls
+            elapsedMs={elapsedMs}
+            onStart={handleStart}
+            onPauseToggle={handlePauseToggle}
+            onRestart={handleRestart}
+            canStart={canStart}
+            isRunning={isRunning}
+            isPaused={isPaused}
+            isCollapsed={isMissionCollapsed}
+            onToggleCollapse={() => setIsMissionCollapsed((state) => !state)}
+          />
         </div>
         <ShipLog entries={logEntries} />
         <MapViewport
@@ -605,6 +1079,9 @@ function App() {
           progress={progress}
           milestones={currentRoute?.milestones ?? []}
           submarinePosition={submarinePosition}
+          obstacles={obstacles}
+          onAddObstacle={addObstacle}
+          isRunning={isRunning && !isPaused}
         />
       </main>
       {isCrewExpanded ? (


### PR DESCRIPTION
## Summary
- make the crew sidebar and mission control panels collapsible while resizing the viewport so the map fits without scrolling
- lock route selections after launch, refresh the submarine icon, and surface an in-map console for injecting obstacles
- orchestrate crew chatter around injected hazards with asynchronous log updates for a livelier mission log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8802a33a4832e83bdbd19abaf2eab