### PR TITLE
Implement crew stress analytics and mission dashboard updates

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -112,6 +112,77 @@ body {
   font-size: 0.95rem;
 }
 
+.crew-sidebar__summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.crew-sidebar__aggregate {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(16, 32, 58, 0.6);
+  border: 1px solid rgba(86, 128, 208, 0.32);
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.crew-sidebar__aggregate--calm {
+  border-color: rgba(108, 210, 176, 0.55);
+}
+
+.crew-sidebar__aggregate--steady {
+  border-color: rgba(108, 174, 255, 0.55);
+}
+
+.crew-sidebar__aggregate--strained {
+  border-color: rgba(255, 194, 118, 0.55);
+}
+
+.crew-sidebar__aggregate--critical {
+  border-color: rgba(255, 118, 136, 0.6);
+}
+
+.crew-sidebar__aggregate-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(190, 209, 245, 0.72);
+}
+
+.crew-sidebar__aggregate-value {
+  font-weight: 600;
+  color: #f6fbff;
+  text-align: center;
+}
+
+.crew-sidebar__aggregate-value--calm {
+  color: #7be0b3;
+}
+
+.crew-sidebar__aggregate-value--steady {
+  color: #7ac8ff;
+}
+
+.crew-sidebar__aggregate-value--strained {
+  color: #ffc371;
+}
+
+.crew-sidebar__aggregate-value--critical {
+  color: #ff7b7b;
+}
+
+.crew-sidebar__rotation {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(202, 217, 247, 0.78);
+  text-align: center;
+}
+
 .crew-sidebar__list {
   list-style: none;
   margin: 0;
@@ -122,9 +193,9 @@ body {
 
 .crew-sidebar__list li {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.6rem 0.75rem;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.7rem 0.75rem;
   border-radius: 14px;
   background: rgba(12, 28, 51, 0.7);
   border: 1px solid rgba(70, 116, 204, 0.32);
@@ -138,6 +209,87 @@ body {
 
 .crew-units {
   color: rgba(196, 215, 255, 0.9);
+}
+
+.crew-list__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.crew-list__name {
+  margin: 0.1rem 0 0;
+  font-size: 0.82rem;
+  color: rgba(194, 212, 247, 0.78);
+}
+
+.crew-metric {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.crew-metric__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(184, 205, 242, 0.68);
+}
+
+.crew-metric__bar {
+  flex: 1;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(20, 42, 78, 0.65);
+  overflow: hidden;
+  position: relative;
+}
+
+.crew-metric__fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.crew-metric__fill--calm {
+  background: linear-gradient(90deg, rgba(80, 200, 180, 0.9), rgba(126, 220, 180, 0.85));
+}
+
+.crew-metric__fill--steady {
+  background: linear-gradient(90deg, rgba(86, 160, 255, 0.9), rgba(136, 196, 255, 0.85));
+}
+
+.crew-metric__fill--strained {
+  background: linear-gradient(90deg, rgba(255, 184, 90, 0.92), rgba(255, 204, 133, 0.85));
+}
+
+.crew-metric__fill--critical {
+  background: linear-gradient(90deg, rgba(255, 102, 118, 0.95), rgba(255, 140, 150, 0.88));
+}
+
+.crew-metric__fill--fatigue {
+  background: linear-gradient(90deg, rgba(160, 125, 255, 0.92), rgba(200, 165, 255, 0.85));
+}
+
+.crew-metric__value {
+  font-weight: 600;
+  min-width: 3ch;
+  text-align: right;
+}
+
+.crew-metric__subtle {
+  font-size: 0.78rem;
+  color: rgba(189, 208, 247, 0.7);
+}
+
+.crew-metric--inline {
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.crew-metric--inline .crew-metric__label {
+  font-size: 0.72rem;
 }
 
 .crew-sidebar__button {
@@ -458,6 +610,172 @@ body {
   color: rgba(210, 226, 255, 0.88);
 }
 
+.map-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  background: rgba(5, 15, 30, 0.78);
+  border-radius: 22px;
+  border: 1px solid rgba(70, 118, 209, 0.35);
+  padding: 1rem 1rem 1.25rem;
+  min-height: 0;
+}
+
+.map-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.map-panel__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.map-panel__header p {
+  margin: 0.35rem 0 0;
+  font-size: 0.88rem;
+  color: rgba(190, 209, 247, 0.75);
+}
+
+.map-panel__header button {
+  padding: 0.45rem 0.7rem;
+  border-radius: 10px;
+  border: 1px solid rgba(110, 162, 255, 0.45);
+  background: rgba(10, 24, 44, 0.95);
+  color: #f1f6ff;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+
+.map-panel--collapsed {
+  align-items: stretch;
+}
+
+.map-panel__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.map-panel__stat {
+  background: rgba(10, 26, 48, 0.78);
+  border: 1px solid rgba(92, 138, 221, 0.4);
+  border-radius: 14px;
+  padding: 0.6rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: center;
+}
+
+.map-panel__stat span {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(185, 205, 244, 0.68);
+}
+
+.map-panel__stat strong {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #f4f9ff;
+}
+
+.map-panel__footer {
+  border-top: 1px solid rgba(74, 118, 205, 0.3);
+  padding-top: 0.75rem;
+}
+
+.map-overlay {
+  position: absolute;
+  left: 1.25rem;
+  right: 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  pointer-events: none;
+}
+
+.map-overlay--top {
+  top: 1.25rem;
+}
+
+.map-overlay__chip {
+  background: rgba(5, 15, 30, 0.72);
+  border: 1px solid rgba(100, 150, 230, 0.4);
+  border-radius: 12px;
+  padding: 0.4rem 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  pointer-events: auto;
+}
+
+.map-overlay__chip span {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(194, 212, 247, 0.75);
+}
+
+.map-overlay__chip strong {
+  font-size: 0.95rem;
+  color: #f6fbff;
+}
+
+.map-overlay__chip--calm {
+  border-color: rgba(106, 210, 176, 0.55);
+}
+
+.map-overlay__chip--steady {
+  border-color: rgba(108, 174, 255, 0.55);
+}
+
+.map-overlay__chip--strained {
+  border-color: rgba(255, 193, 118, 0.55);
+}
+
+.map-overlay__chip--critical {
+  border-color: rgba(255, 118, 136, 0.6);
+}
+
+.resource-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.85rem;
+}
+
+.resource-grid > div {
+  background: rgba(10, 28, 54, 0.68);
+  border: 1px solid rgba(90, 138, 226, 0.35);
+  border-radius: 14px;
+  padding: 0.6rem 0.75rem;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.resource-grid span {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(188, 206, 245, 0.7);
+}
+
+.resource-grid strong {
+  font-size: 1.05rem;
+  color: #f7fbff;
+}
+
+.resource-grid p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(189, 209, 247, 0.72);
+}
+
 .map-viewport {
   width: 100%;
   height: 100%;
@@ -632,6 +950,30 @@ body {
   color: rgba(204, 222, 255, 0.75);
 }
 
+.crew-briefing__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.85rem;
+}
+
+.crew-briefing__summary > div {
+  background: rgba(14, 30, 52, 0.72);
+  border: 1px solid rgba(93, 140, 223, 0.4);
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.crew-briefing__summary-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(189, 207, 245, 0.7);
+}
+
 .crew-briefing__content {
   display: grid;
   gap: 1rem;
@@ -639,13 +981,69 @@ body {
   padding-right: 0.25rem;
 }
 
-.crew-card {
+.crew-card { 
   background: rgba(12, 32, 58, 0.72);
   border-radius: 18px;
   border: 1px solid rgba(90, 141, 228, 0.4);
   padding: 1rem 1.25rem;
   display: grid;
   gap: 0.75rem;
+}
+
+.crew-card__stress {
+  border-radius: 12px;
+  padding: 0.75rem 0.85rem;
+  background: rgba(18, 40, 72, 0.75);
+  border: 1px solid rgba(95, 145, 229, 0.38);
+  display: grid;
+  gap: 0.3rem;
+}
+
+.crew-card__stress-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(188, 208, 248, 0.7);
+}
+
+.crew-card__stress--calm {
+  border-color: rgba(108, 210, 176, 0.55);
+  background: rgba(34, 70, 62, 0.4);
+}
+
+.crew-card__stress--steady {
+  border-color: rgba(108, 174, 255, 0.55);
+  background: rgba(30, 54, 88, 0.5);
+}
+
+.crew-card__stress--strained {
+  border-color: rgba(255, 194, 118, 0.55);
+  background: rgba(72, 54, 28, 0.4);
+}
+
+.crew-card__stress--critical {
+  border-color: rgba(255, 118, 136, 0.6);
+  background: rgba(78, 32, 40, 0.45);
+}
+
+.crew-card__stress p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(214, 226, 255, 0.78);
+}
+
+.crew-card__staffing {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: rgba(198, 214, 247, 0.78);
+}
+
+.crew-card__hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(188, 208, 248, 0.68);
 }
 
 .crew-card__header {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,12 +10,26 @@ const MAP_WIDTH = 1280
 const MAP_HEIGHT = 720
 const TIME_SCALE = Number(import.meta.env.VITE_SIMULATION_TIME_SCALE ?? 1)
 
+const SIMULATION_MINUTES_PER_MISSION_MINUTE = 120
+const SHIFT_LENGTH_HOURS = 6
+const FATIGUE_RATE_ON_DUTY = 3.2
+const FATIGUE_RECOVERY_PER_HOUR = 2.6
+const STRESS_RATE_ON_DUTY = 2.1
+const STRESS_RECOVERY_PER_HOUR = 1.4
+const STRESS_FROM_FATIGUE = 1.05
+
+const FUEL_TANK_CAPACITY_LITERS = 720_000
+const BASE_FUEL_BURN_PER_HOUR = 2_050
+const ADDITIONAL_BURN_PER_CREW_UNIT = 18
+const STRESS_FUEL_MULTIPLIER = 0.35
+
 const OBSTACLE_TYPES = {
   battleship: {
     label: 'Battleship screen',
     description: 'Surface fleet interdiction detected ahead of the cable corridor.',
     iconColor: '#f78c6b',
-    analystReport: 'Surface contact designated as hostile destroyer screen. Recommend veer five degrees port and drop to 180m.',
+    analystReport:
+      'Surface contact designated as hostile destroyer screen. Recommend veer five degrees port and drop to 180m.',
     captainDirective:
       'Captain Mira Chen: Navigation, execute the port veer and keep ballast trimmed. Intel, maintain sonar picture every thirty seconds.',
     operationsFollowUp:
@@ -51,53 +65,90 @@ const OBSTACLE_TYPES = {
 const HEARTBEAT_TASKS = [
   {
     crewId: 'intel',
-    buildTranscript: ({ crewMember }) =>
-      `${crewMember.name}: Sensor fusion cycle green; hazards queued for bridge review.`,
-    buildThoughts: ({ telemetry }) => [
-      'Refreshing maritime intelligence overlays.',
-      `Monitoring corridor at ${(telemetry.progress * 100).toFixed(0)}% completion.`,
-      'Scheduling next threat broadcast to the command deck.',
-    ],
+    buildTranscript: ({ crewMember, metrics }) => {
+      const efficiency = metrics ? Math.round(metrics.efficiency * 100) : 100
+      const stress = describeStressLevel(metrics?.stress ?? 0)
+      return `${crewMember.name}: Sensor fusion at ${efficiency}% efficiency — ${stress.label.toLowerCase()} posture maintained.`
+    },
+    buildThoughts: ({ telemetry, metrics }) => {
+      const watchSummary = metrics
+        ? `${metrics.awakeUnits} analysts on watch, ${metrics.restingUnits} recovering.`
+        : 'Balancing analyst rotations.'
+      return [
+        'Refreshing maritime intelligence overlays with fresh satellite passes.',
+        `Monitoring corridor at ${(telemetry.progress * 100).toFixed(0)}% completion.`,
+        watchSummary,
+      ]
+    },
   },
   {
     crewId: 'captain',
-    buildTranscript: ({ crewMember }) =>
-      `${crewMember.name}: Maintain cadence and report deviations immediately.`,
-    buildThoughts: ({ telemetry }) => [
-      `Reviewing bridge status at T+${formatTime(telemetry.elapsedMs)}.`,
-      'Confirming navigation offsets align with mission plan.',
-      'Coordinating readiness posture with operations.',
-    ],
+    buildTranscript: ({ crewMember, metrics }) => {
+      const stress = describeStressLevel(metrics?.stress ?? 0)
+      return `${crewMember.name}: Maintain cadence; bridge remains ${stress.label.toLowerCase()} under current load.`
+    },
+    buildThoughts: ({ telemetry, metrics }) => {
+      const efficiency = metrics ? Math.round(metrics.efficiency * 100) : 100
+      const rest = metrics && metrics.restingUnits > 0 ? `${metrics.restingUnits} officers off-shift.` : 'Command deck fully engaged.'
+      return [
+        `Reviewing bridge status at T+${formatTime(telemetry.elapsedMs)}.`,
+        `Mission efficiency projected at ${efficiency}% for the next watch.`,
+        rest,
+      ]
+    },
   },
   {
     crewId: 'engineer',
-    buildTranscript: ({ crewMember }) =>
-      `${crewMember.name}: Thermal envelopes steady; rerouting spare capacity to maneuvering.`,
-    buildThoughts: () => [
-      'Sweeping diagnostics across propulsion pods.',
-      'Balancing reactor output with ballast adjustments.',
-      'Logging engineering status to systems console.',
-    ],
+    buildTranscript: ({ crewMember, metrics }) => {
+      const stress = describeStressLevel(metrics?.stress ?? 0)
+      return `${crewMember.name}: Thermal envelopes steady; engineering watch is ${stress.label.toLowerCase()}.`
+    },
+    buildThoughts: ({ metrics }) => {
+      const fatigue = metrics ? Math.round(metrics.fatigue) : 0
+      const rotation = metrics
+        ? `${metrics.awakeUnits} specialists managing propulsion while ${metrics.restingUnits} recover.`
+        : 'Propulsion teams managing standard rotations.'
+      return [
+        'Sweeping diagnostics across propulsion pods.',
+        rotation,
+        `Fatigue trending at ${fatigue}% — recalibrating coolant trims accordingly.`,
+      ]
+    },
   },
   {
     crewId: 'navigator',
-    buildTranscript: ({ crewMember }) =>
-      `${crewMember.name}: Waypoints locked — autopilot gliding along the cable grade.`,
-    buildThoughts: ({ telemetry }) => [
-      `Interpolating bathymetry at ${(telemetry.progress * 100).toFixed(1)}% of route.`,
-      'Checking helm inputs for micro-corrections.',
-      'Synchronizing updates with mission command.',
-    ],
+    buildTranscript: ({ crewMember, metrics }) => {
+      const stress = describeStressLevel(metrics?.stress ?? 0)
+      return `${crewMember.name}: Waypoints locked — nav team ${stress.label.toLowerCase()} as we trace the grade.`
+    },
+    buildThoughts: ({ telemetry, metrics }) => {
+      const efficiency = metrics ? Math.round(metrics.efficiency * 100) : 100
+      return [
+        `Interpolating bathymetry at ${(telemetry.progress * 100).toFixed(1)}% of route.`,
+        `Current helm efficiency steady at ${efficiency}%.`,
+        metrics
+          ? `${metrics.awakeUnits} charting specialists awake, ${metrics.restingUnits} rotating to rest.`
+          : 'Synchronizing updates with mission command.',
+      ]
+    },
   },
   {
     crewId: 'operations',
-    buildTranscript: ({ crewMember }) =>
-      `${crewMember.name}: Crew rotations steady; obstacle drills ready on short notice.`,
-    buildThoughts: () => [
-      'Auditing compartment readiness reports.',
-      'Coordinating with engineering for contingency rehearsals.',
-      'Updating ship log tasks for next rotation.',
-    ],
+    buildTranscript: ({ crewMember, metrics }) => {
+      const stress = describeStressLevel(metrics?.stress ?? 0)
+      return `${crewMember.name}: Crew rotations steady; operations posture ${stress.label.toLowerCase()}.`
+    },
+    buildThoughts: ({ metrics }) => {
+      const fatigue = metrics ? Math.round(metrics.fatigue) : 0
+      const rest = metrics && metrics.restingUnits > 0
+        ? `${metrics.restingUnits} coordinators off-shift to manage fatigue.`
+        : 'No reserve teams remaining — monitoring morale closely.'
+      return [
+        'Auditing compartment readiness reports.',
+        rest,
+        `Tracking fatigue at ${fatigue}% to plan relief timings.`,
+      ]
+    },
   },
 ]
 
@@ -121,18 +172,110 @@ function formatTime(totalMs) {
   return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
 }
 
-function groupCrewByRole(crew) {
-  return crew.reduce((acc, member) => {
-    const entry = acc.get(member.role) ?? { units: 0, members: [] }
-    entry.units += member.units
-    entry.members.push(member)
-    acc.set(member.role, entry)
-    return acc
-  }, new Map())
+function clamp(value, min, max) {
+  if (Number.isNaN(value)) return min
+  return Math.min(Math.max(value, min), max)
+}
+
+function degreesToRadians(value) {
+  return (value * Math.PI) / 180
+}
+
+function computeRouteDistanceNauticalMiles(path) {
+  if (!Array.isArray(path) || path.length < 2) return 0
+  let totalKm = 0
+  for (let index = 1; index < path.length; index += 1) {
+    const start = path[index - 1]
+    const end = path[index]
+    const lat1 = degreesToRadians(start.latitude)
+    const lon1 = degreesToRadians(start.longitude)
+    const lat2 = degreesToRadians(end.latitude)
+    const lon2 = degreesToRadians(end.longitude)
+    const deltaLat = lat2 - lat1
+    const deltaLon = lon2 - lon1
+    const a = Math.sin(deltaLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(deltaLon / 2) ** 2
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+    const EARTH_RADIUS_KM = 6371
+    totalKm += EARTH_RADIUS_KM * c
+  }
+  return totalKm * 0.539957
+}
+
+function formatNauticalMiles(value) {
+  if (!Number.isFinite(value)) return '0 nm'
+  if (value >= 100) return `${value.toFixed(0)} nm`
+  return `${value.toFixed(1)} nm`
+}
+
+function formatLiters(value, fractionDigits = 0) {
+  if (!Number.isFinite(value)) return '0 L'
+  return `${value.toLocaleString(undefined, {
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: fractionDigits,
+  })} L`
+}
+
+function formatHours(hours) {
+  if (!Number.isFinite(hours)) return '0h'
+  const whole = Math.floor(hours)
+  const minutes = Math.round((hours - whole) * 60)
+  if (whole <= 0) {
+    return `${minutes}m`
+  }
+  return `${whole}h ${minutes.toString().padStart(2, '0')}m`
+}
+
+function describeStressLevel(stressValue) {
+  const value = clamp(stressValue, 0, 100)
+  if (value < 25) {
+    return { label: 'Composed', tone: 'calm', narrative: 'Crew responses remain steady with low stress signatures.' }
+  }
+  if (value < 50) {
+    return {
+      label: 'Steady',
+      tone: 'steady',
+      narrative: 'Teams are alert but comfortable with the workload.',
+    }
+  }
+  if (value < 75) {
+    return {
+      label: 'Strained',
+      tone: 'strained',
+      narrative: 'Watch rotations are tightening; consider reinforcing support.',
+    }
+  }
+  return {
+    label: 'Critical',
+    tone: 'critical',
+    narrative: 'Stress spikes are compromising decision cadence.',
+  }
+}
+
+function createInitialMetrics(member) {
+  const teamSize = member.teamSize ?? (member.role === 'Mission Command' ? 1 : 2)
+  const totalTeams = Math.max(1, Math.ceil(member.units / teamSize))
+  const awakeUnits = Math.min(member.units, teamSize)
+  return {
+    stress: 22,
+    fatigue: 18,
+    efficiency: 0.94,
+    awakeUnits,
+    restingUnits: Math.max(0, member.units - awakeUnits),
+    totalTeams,
+    teamSize,
+    clock: 0,
+    shiftIndex: 0,
+  }
 }
 
 function CrewSidebar({
-  crewSummary,
+  crewState,
+  crewMetrics,
+  aggregateStress,
+  stressGrade,
+  totalCrewUnits,
+  rotationSummary,
+  peakTeamStress,
   onOpenBriefing,
   isPaused,
   canResume,
@@ -157,10 +300,25 @@ function CrewSidebar({
         <span className={isPaused ? 'status-dot paused' : 'status-dot running'} aria-hidden="true" />
         <span>{isPaused ? (canResume ? 'Paused' : 'Awaiting launch') : 'Underway'}</span>
       </div>
-      {isCollapsed ? (
-        <div className="crew-sidebar__compact">
-          <h1>Global Cable Traverse</h1>
-          <button
+        {isCollapsed ? (
+          <div className="crew-sidebar__compact">
+            <h1>Global Cable Traverse</h1>
+            <div className={`crew-sidebar__aggregate crew-sidebar__aggregate--${stressGrade.tone}`}>
+              <span className="crew-sidebar__aggregate-label">Team stress</span>
+              <span className="crew-sidebar__aggregate-value">
+                {stressGrade.label} ({Math.round(aggregateStress)}%)
+              </span>
+            </div>
+            <div className="crew-sidebar__aggregate">
+              <span className="crew-sidebar__aggregate-label">Crew complement</span>
+              <span className="crew-sidebar__aggregate-value">{totalCrewUnits} specialists</span>
+            </div>
+            <div className="crew-sidebar__aggregate">
+              <span className="crew-sidebar__aggregate-label">Peak stress</span>
+              <span className="crew-sidebar__aggregate-value">{Math.round(peakTeamStress)}%</span>
+            </div>
+            <p className="crew-sidebar__rotation">{rotationSummary}</p>
+            <button
             type="button"
             className="crew-sidebar__button crew-sidebar__button--icon"
             onClick={onOpenBriefing}
@@ -171,23 +329,92 @@ function CrewSidebar({
         </div>
       ) : (
         <div id="crew-sidebar-content" className="crew-sidebar__content">
-          <header className="crew-sidebar__header">
-            <h1>Global Cable Traverse</h1>
-            <p>Monitor crew allotments while the submarine follows intercontinental fiber routes.</p>
-          </header>
+            <header className="crew-sidebar__header">
+              <h1>Global Cable Traverse</h1>
+              <p>{stressGrade.narrative}</p>
+              <div className="crew-sidebar__summary-grid">
+                <div>
+                  <span className="crew-sidebar__aggregate-label">Team stress</span>
+                  <strong className={`crew-sidebar__aggregate-value crew-sidebar__aggregate-value--${stressGrade.tone}`}>
+                    {stressGrade.label} ({Math.round(aggregateStress)}%)
+                  </strong>
+                </div>
+                <div>
+                  <span className="crew-sidebar__aggregate-label">Crew complement</span>
+                  <strong className="crew-sidebar__aggregate-value">{totalCrewUnits} specialists</strong>
+                </div>
+                <div>
+                  <span className="crew-sidebar__aggregate-label">Rotation</span>
+                  <strong className="crew-sidebar__aggregate-value">{rotationSummary}</strong>
+                </div>
+                <div>
+                  <span className="crew-sidebar__aggregate-label">Peak stress</span>
+                  <strong className="crew-sidebar__aggregate-value">{Math.round(peakTeamStress)}%</strong>
+                </div>
+              </div>
+            </header>
           <ul className="crew-sidebar__list">
-            {crewSummary.map(({ role, units }) => (
-              <li key={role}>
-                <span className="crew-role">{role}</span>
-                <span className="crew-units">{units} units</span>
-              </li>
-            ))}
+            {crewState.map((member) => {
+              const metrics = crewMetrics[member.id]
+              const stressValue = metrics ? Math.round(metrics.stress) : 0
+              const fatigueValue = metrics ? Math.round(metrics.fatigue) : 0
+              const efficiency = metrics ? Math.round(metrics.efficiency * 100) : 100
+              const memberStress = describeStressLevel(stressValue)
+              const rotationInfo = metrics
+                ? `${metrics.awakeUnits} on watch / ${metrics.restingUnits} resting`
+                : 'Establishing sleep cycles'
+              return (
+                <li key={member.id}>
+                  <div className="crew-list__header">
+                    <div>
+                      <span className="crew-role">{member.role}</span>
+                      <p className="crew-list__name">{member.name}</p>
+                    </div>
+                    <span className="crew-units">{member.units} units</span>
+                  </div>
+                  <div className="crew-metric" role="group" aria-label={`${member.name} stress level`}>
+                    <span className="crew-metric__label">Stress</span>
+                    <div
+                      className="crew-metric__bar"
+                      role="progressbar"
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-valuenow={stressValue}
+                    >
+                      <span
+                        className={`crew-metric__fill crew-metric__fill--${memberStress.tone}`}
+                        style={{ width: `${stressValue}%` }}
+                      />
+                    </div>
+                    <span className="crew-metric__value">{stressValue}%</span>
+                  </div>
+                  <div className="crew-metric" role="group" aria-label={`${member.name} fatigue level`}>
+                    <span className="crew-metric__label">Fatigue</span>
+                    <div
+                      className="crew-metric__bar"
+                      role="progressbar"
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-valuenow={fatigueValue}
+                    >
+                      <span className="crew-metric__fill crew-metric__fill--fatigue" style={{ width: `${fatigueValue}%` }} />
+                    </div>
+                    <span className="crew-metric__value">{fatigueValue}%</span>
+                  </div>
+                  <div className="crew-metric crew-metric--inline" role="group" aria-label={`${member.name} efficiency`}>
+                    <span className="crew-metric__label">Efficiency</span>
+                    <strong className="crew-metric__value">{efficiency}%</strong>
+                    <span className="crew-metric__subtle">{rotationInfo}</span>
+                  </div>
+                </li>
+              )
+            })}
           </ul>
           <button type="button" className="crew-sidebar__button" onClick={onOpenBriefing}>
             View crew instructions
           </button>
           <p className="crew-sidebar__hint">
-            Expanding the crew briefing pauses the voyage so you can adjust directives and alliances.
+            Expanding the crew briefing pauses the voyage so you can adjust directives, alliances, and staffing.
           </p>
         </div>
       )}
@@ -197,9 +424,13 @@ function CrewSidebar({
 
 function CrewBriefingOverlay({
   crewState,
+  crewMetrics,
   onClose,
   onUpdateInstructions,
   onUpdateAlliances,
+  onUpdateUnits,
+  canModifyStaffing,
+  resourceStats,
 }) {
   return (
     <div className="crew-briefing" role="dialog" aria-modal="true">
@@ -207,47 +438,109 @@ function CrewBriefingOverlay({
         <header>
           <h2>Crew Instructions & Alliances</h2>
           <p>
-            Adjust guidance and collaborative ties for each specialist. Changes apply immediately once you resume the
-            voyage.
+            Adjust guidance, collaborative ties, and staffing for each specialist. Changes apply immediately once you resume
+            the voyage.
           </p>
+          <div className="crew-briefing__summary">
+            <div>
+              <span className="crew-briefing__summary-label">Fuel burn</span>
+              <strong>{formatLiters(resourceStats.burnRate, 0)} / hr</strong>
+            </div>
+            <div>
+              <span className="crew-briefing__summary-label">Fuel used</span>
+              <strong>{resourceStats.fuelPercentage.toFixed(1)}%</strong>
+            </div>
+            <div>
+              <span className="crew-briefing__summary-label">Endurance</span>
+              <strong>{formatHours(resourceStats.enduranceHours)}</strong>
+            </div>
+          </div>
         </header>
         <div className="crew-briefing__content">
-          {crewState.map((member) => (
-            <section key={member.id} className="crew-card">
-              <header className="crew-card__header">
-                <div>
-                  <h3>{member.name}</h3>
-                  <p>{member.role}</p>
+          {crewState.map((member) => {
+            const metrics = crewMetrics[member.id]
+            const stress = metrics ? Math.round(metrics.stress) : 0
+            const fatigue = metrics ? Math.round(metrics.fatigue) : 0
+            const efficiency = metrics ? Math.round(metrics.efficiency * 100) : 100
+            const stressInfo = describeStressLevel(stress)
+            const totalTeams = metrics?.totalTeams ?? Math.max(1, Math.ceil(member.units / (member.teamSize ?? 1)))
+            const shiftProgress = metrics ? metrics.clock % SHIFT_LENGTH_HOURS : 0
+            const timeToRotation = metrics
+              ? shiftProgress === 0
+                ? SHIFT_LENGTH_HOURS
+                : SHIFT_LENGTH_HOURS - shiftProgress
+              : SHIFT_LENGTH_HOURS
+
+            return (
+              <section key={member.id} className="crew-card">
+                <header className="crew-card__header">
+                  <div>
+                    <h3>{member.name}</h3>
+                    <p>{member.role}</p>
+                  </div>
+                  <span>{member.units} units</span>
+                </header>
+                <div className={`crew-card__stress crew-card__stress--${stressInfo.tone}`}>
+                  <div>
+                    <span className="crew-card__stress-label">Stress posture</span>
+                    <strong>{stressInfo.label}</strong>
+                  </div>
+                  <p>
+                    Stress {stress}% · Fatigue {fatigue}% · Efficiency {efficiency}% · Teams {totalTeams}
+                  </p>
+                  <p>Next rotation in {formatHours(timeToRotation)}</p>
                 </div>
-                <span>{member.units} units</span>
-              </header>
-              <label className="crew-card__label" htmlFor={`instructions-${member.id}`}>
-                Directives
-              </label>
-              <textarea
-                id={`instructions-${member.id}`}
-                value={member.instructions}
-                onChange={(event) => onUpdateInstructions(member.id, event.target.value)}
-                rows={3}
-              />
-              <label className="crew-card__label" htmlFor={`alliances-${member.id}`}>
-                Collaborative alliances (comma separated)
-              </label>
-              <input
-                id={`alliances-${member.id}`}
-                value={member.alliances.join(', ')}
-                onChange={(event) =>
-                  onUpdateAlliances(
-                    member.id,
-                    event.target.value
-                      .split(',')
-                      .map((item) => item.trim())
-                      .filter(Boolean),
-                  )
-                }
-              />
-            </section>
-          ))}
+                <label className="crew-card__label" htmlFor={`units-${member.id}`}>
+                  Staffing level
+                </label>
+                <input
+                  id={`units-${member.id}`}
+                  type="range"
+                  min={member.minUnits}
+                  max={member.maxUnits}
+                  value={member.units}
+                  onChange={(event) => onUpdateUnits(member.id, Number(event.target.value))}
+                  disabled={!canModifyStaffing}
+                />
+                <div className="crew-card__staffing">
+                  <span>{member.units} specialists</span>
+                  <span>
+                    Allowable range {member.minUnits}–{member.maxUnits}
+                  </span>
+                </div>
+                <p className="crew-card__hint">
+                  {canModifyStaffing
+                    ? 'Increase teams for healthier sleep rotations at the cost of fuel and supplies.'
+                    : 'Staffing locked while underway — adjustments resume once the vessel is docked.'}
+                </p>
+                <label className="crew-card__label" htmlFor={`instructions-${member.id}`}>
+                  Directives
+                </label>
+                <textarea
+                  id={`instructions-${member.id}`}
+                  value={member.instructions}
+                  onChange={(event) => onUpdateInstructions(member.id, event.target.value)}
+                  rows={3}
+                />
+                <label className="crew-card__label" htmlFor={`alliances-${member.id}`}>
+                  Collaborative alliances (comma separated)
+                </label>
+                <input
+                  id={`alliances-${member.id}`}
+                  value={member.alliances.join(', ')}
+                  onChange={(event) =>
+                    onUpdateAlliances(
+                      member.id,
+                      event.target.value
+                        .split(',')
+                        .map((item) => item.trim())
+                        .filter(Boolean),
+                    )
+                  }
+                />
+              </section>
+            )
+          })}
         </div>
         <footer>
           <button type="button" onClick={onClose} className="crew-briefing__close">
@@ -426,6 +719,12 @@ function MapViewport({
   obstacles,
   onAddObstacle,
   isRunning,
+  isCollapsed,
+  onToggleCollapse,
+  telemetrySummary,
+  resourceStats,
+  aggregateStress,
+  stressGrade,
 }) {
   const projectedRoute = useMemo(() => {
     if (!route) return []
@@ -474,95 +773,164 @@ function MapViewport({
   }, [route, obstacles])
 
   return (
-    <div className="map-wrapper">
-      <svg
-        className="map-viewport"
-        viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
-        role="img"
-        aria-label="Global submarine cable voyage"
-        preserveAspectRatio="xMidYMid meet"
-      >
-        <defs>
-          <linearGradient id="ocean" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stopColor="#082032" />
-            <stop offset="100%" stopColor="#0c4160" />
-          </linearGradient>
-        </defs>
-        <rect width={MAP_WIDTH} height={MAP_HEIGHT} fill="url(#ocean)" />
-        <g className="world-outline">
-          {worldPolygons.map((feature) => (
-            <polygon
-              key={feature.id}
-              points={feature.coordinates.map(([lon, lat]) => projectPoint({ latitude: lat, longitude: lon }).join(',')).join(' ')}
-            />
-          ))}
-        </g>
-        {projectedRoute.length ? (
-          <g className="route-path">
-            <polyline points={projectedRoute.map(([x, y]) => `${x},${y}`).join(' ')} />
-            {projectedMilestones.map((milestone) =>
-              milestone ? (
-                <g key={milestone.id} className="route-milestone" transform={`translate(${milestone.coordinates[0]}, ${milestone.coordinates[1]})`}>
-                  <circle r="8" />
-                  <text x="12" y="4">{milestone.label}</text>
-                </g>
-              ) : null,
-            )}
-          </g>
-        ) : null}
-        {projectedObstacles.map((obstacle) => {
-          if (!obstacle) return null
-          const config = OBSTACLE_TYPES[obstacle.type] ?? {}
-          return (
-            <g
-              key={obstacle.id}
-              className={obstacle.resolved ? 'map-obstacle map-obstacle--resolved' : 'map-obstacle'}
-              transform={`translate(${obstacle.coordinates[0]}, ${obstacle.coordinates[1]})`}
+    <section className={isCollapsed ? 'map-panel map-panel--collapsed' : 'map-panel'} aria-label="Operational map">
+      <header className="map-panel__header">
+        <div>
+          <h2>Operational Map</h2>
+          <p>
+            Team stress {stressGrade.label.toLowerCase()} ({Math.round(aggregateStress)}%) · Fuel used {resourceStats.fuelPercentage.toFixed(1)}%
+          </p>
+        </div>
+        <button type="button" onClick={onToggleCollapse} aria-expanded={!isCollapsed}>
+          {isCollapsed ? 'Expand map' : 'Collapse map'}
+        </button>
+      </header>
+      {isCollapsed ? (
+        <div className="map-panel__stats" role="list">
+          <div className="map-panel__stat" role="listitem">
+            <span>Elapsed</span>
+            <strong>{telemetrySummary.elapsedLabel}</strong>
+          </div>
+          <div className="map-panel__stat" role="listitem">
+            <span>Milestones</span>
+            <strong>{telemetrySummary.milestonesLabel}</strong>
+          </div>
+          <div className="map-panel__stat" role="listitem">
+            <span>Remaining distance</span>
+            <strong>{telemetrySummary.remainingDistanceLabel}</strong>
+          </div>
+          <div className="map-panel__stat" role="listitem">
+            <span>Depth</span>
+            <strong>{telemetrySummary.depthLabel}</strong>
+          </div>
+          <div className="map-panel__stat" role="listitem">
+            <span>Crew size</span>
+            <strong>{telemetrySummary.crewLabel}</strong>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="map-wrapper">
+            <svg
+              className="map-viewport"
+              role="img"
+              aria-label="World map with submarine route"
+              viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
             >
-              <circle r="14" fill={config.iconColor ?? '#ffffff'} />
-              <path d="M-10,0 L10,0 M0,-10 L0,10" stroke={config.iconColor ?? '#ffffff'} />
-              <text x="0" y="26" textAnchor="middle">
-                {config.label ?? 'Hazard'}
+              <g className="world-outline">
+                {worldPolygons.map((feature) => (
+                  <polygon
+                    key={feature.id}
+                    points={feature.coordinates
+                      .map(([lon, lat]) => projectPoint({ latitude: lat, longitude: lon }).join(','))
+                      .join(' ')}
+                  />
+                ))}
+              </g>
+              {projectedRoute.length ? (
+                <g className="route-path">
+                  <polyline points={projectedRoute.map(([x, y]) => `${x},${y}`).join(' ')} />
+                  {projectedMilestones.map((milestone) =>
+                    milestone ? (
+                      <g
+                        key={milestone.id}
+                        className="route-milestone"
+                        transform={`translate(${milestone.coordinates[0]}, ${milestone.coordinates[1]})`}
+                      >
+                        <circle r="8" />
+                        <text x="12" y="4">
+                          {milestone.label}
+                        </text>
+                      </g>
+                    ) : null,
+                  )}
+                </g>
+              ) : null}
+              {projectedObstacles.map((obstacle) => {
+                if (!obstacle) return null
+                const config = OBSTACLE_TYPES[obstacle.type] ?? {}
+                return (
+                  <g
+                    key={obstacle.id}
+                    className={obstacle.resolved ? 'map-obstacle map-obstacle--resolved' : 'map-obstacle'}
+                    transform={`translate(${obstacle.coordinates[0]}, ${obstacle.coordinates[1]})`}
+                  >
+                    <circle r="14" fill={config.iconColor ?? '#ffffff'} />
+                    <path d="M-10,0 L10,0 M0,-10 L0,10" stroke={config.iconColor ?? '#ffffff'} />
+                    <text x="0" y="26" textAnchor="middle">
+                      {config.label ?? 'Hazard'}
+                    </text>
+                  </g>
+                )
+              })}
+              {submarinePosition ? (
+                <g className="submarine" transform={`translate(${submarinePosition[0]}, ${submarinePosition[1]})`}>
+                  <ellipse cx="0" cy="0" rx="26" ry="12" />
+                  <rect x="-8" y="-14" width="16" height="10" rx="4" />
+                  <polygon points="26,0 16,-8 16,8" />
+                  <circle cx="-14" cy="0" r="4" />
+                </g>
+              ) : null}
+              {route ? (
+                <g className="port-labels">
+                  <text {...anchorText(resolvePort(route.origin))}>{resolvePort(route.origin).name}</text>
+                  <text {...anchorText(resolvePort(route.destination))}>{resolvePort(route.destination).name}</text>
+                </g>
+              ) : null}
+              <text className="progress-indicator" x={MAP_WIDTH - 24} y={MAP_HEIGHT - 24} textAnchor="end">
+                {Math.round(progress * 100)}% complete
               </text>
-            </g>
-          )
-        })}
-        {submarinePosition ? (
-          <g className="submarine" transform={`translate(${submarinePosition[0]}, ${submarinePosition[1]})`}>
-            <ellipse cx="0" cy="0" rx="26" ry="12" />
-            <rect x="-8" y="-14" width="16" height="10" rx="4" />
-            <polygon points="26,0 16,-8 16,8" />
-            <circle cx="-14" cy="0" r="4" />
-          </g>
-        ) : null}
-        {route ? (
-          <g className="port-labels">
-            <text {...anchorText(resolvePort(route.origin))}>
-              {resolvePort(route.origin).name}
-            </text>
-            <text {...anchorText(resolvePort(route.destination))}>
-              {resolvePort(route.destination).name}
-            </text>
-          </g>
-        ) : null}
-        <text className="progress-indicator" x={MAP_WIDTH - 24} y={MAP_HEIGHT - 24} textAnchor="end">
-          {Math.round(progress * 100)}% complete
-        </text>
-      </svg>
-      <div className="obstacle-console" aria-hidden={!isRunning}>
-        <strong>Inject challenges</strong>
-        {Object.entries(OBSTACLE_TYPES).map(([type, config]) => (
-          <button
-            key={type}
-            type="button"
-            onClick={() => onAddObstacle(type)}
-            disabled={!route || !isRunning}
-          >
-            {config.label}
-          </button>
-        ))}
-      </div>
-    </div>
+            </svg>
+            <div className="map-overlay map-overlay--top">
+              <div className={`map-overlay__chip map-overlay__chip--${stressGrade.tone}`}>
+                <span>Team stress</span>
+                <strong>
+                  {stressGrade.label} ({Math.round(aggregateStress)}%)
+                </strong>
+              </div>
+              <div className="map-overlay__chip">
+                <span>Depth</span>
+                <strong>{telemetrySummary.depthLabel}</strong>
+              </div>
+            </div>
+            <div className="obstacle-console" aria-hidden={!isRunning}>
+              <strong>Inject challenges</strong>
+              {Object.entries(OBSTACLE_TYPES).map(([type, config]) => (
+                <button key={type} type="button" onClick={() => onAddObstacle(type)} disabled={!route || !isRunning}>
+                  {config.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="map-panel__footer">
+            <div className="resource-grid">
+              <div>
+                <span>Fuel consumed</span>
+                <strong>{resourceStats.fuelPercentage.toFixed(1)}%</strong>
+                <p>
+                  {formatLiters(resourceStats.fuelConsumedLiters, 0)} of {formatLiters(resourceStats.tankCapacity, 0)}
+                </p>
+              </div>
+              <div>
+                <span>Burn rate</span>
+                <strong>{formatLiters(resourceStats.burnRate, 0)} / hr</strong>
+                <p>Stress factor ×{resourceStats.stressFactor.toFixed(2)}</p>
+              </div>
+              <div>
+                <span>Endurance</span>
+                <strong>{formatHours(resourceStats.enduranceHours)}</strong>
+                <p>Projected range {formatNauticalMiles(resourceStats.projectedRangeNm)}</p>
+              </div>
+              <div>
+                <span>Crew load</span>
+                <strong>{telemetrySummary.crewLabel}</strong>
+                <p>{telemetrySummary.milestonesLabel}</p>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </section>
   )
 }
 
@@ -577,8 +945,21 @@ function anchorText(port) {
 
 function App() {
   const [crewState, setCrewState] = useState(() =>
-    crewManifest.map((member) => ({ ...member, instructions: member.defaultInstructions.slice() }))
+    crewManifest.map((member) => ({
+      ...member,
+      baseUnits: member.units,
+      instructions: member.defaultInstructions.slice(),
+    })),
   )
+  const [crewMetrics, setCrewMetrics] = useState(() => {
+    const initial = {}
+    crewManifest.forEach((member) => {
+      initial[member.id] = createInitialMetrics(member)
+    })
+    return initial
+  })
+  const crewMetricsRef = useRef(crewMetrics)
+  const crewByIdRef = useRef(new Map())
   const [origin, setOrigin] = useState(null)
   const [destination, setDestination] = useState(null)
   const [progress, setProgress] = useState(0)
@@ -589,12 +970,14 @@ function App() {
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
   const [isRouteCollapsed, setIsRouteCollapsed] = useState(false)
   const [isMissionCollapsed, setIsMissionCollapsed] = useState(false)
+  const [isMapCollapsed, setIsMapCollapsed] = useState(false)
   const [hasLaunched, setHasLaunched] = useState(false)
   const resumeAfterOverlayRef = useRef(false)
   const [logEntries, setLogEntries] = useState([])
   const [triggeredMilestones, setTriggeredMilestones] = useState([])
   const [obstacles, setObstacles] = useState([])
   const previousRouteKeyRef = useRef('none')
+  const [peakTeamStress, setPeakTeamStress] = useState(0)
 
   const animationFrameRef = useRef(null)
   const lastTickRef = useRef(null)
@@ -602,6 +985,7 @@ function App() {
   const heartbeatIntervalRef = useRef(null)
   const crewHeartbeatIndexRef = useRef(0)
   const latestTelemetryRef = useRef({ progress: 0, elapsedMs: 0 })
+  const lastElapsedRef = useRef(0)
 
   const currentRoute = useMemo(() => {
     if (!origin || !destination) return null
@@ -626,6 +1010,36 @@ function App() {
   )
 
   useEffect(() => {
+    crewMetricsRef.current = crewMetrics
+  }, [crewMetrics])
+
+  const crewById = useMemo(() => {
+    const map = new Map()
+    crewState.forEach((member) => map.set(member.id, member))
+    return map
+  }, [crewState])
+
+  useEffect(() => {
+    crewByIdRef.current = crewById
+  }, [crewById])
+
+  const adjustCrewStress = useCallback((crewIds, stressDelta, fatigueDelta = 0) => {
+    setCrewMetrics((metrics) => {
+      const next = { ...metrics }
+      crewIds.forEach((id) => {
+        const current = next[id]
+        if (!current) return
+        next[id] = {
+          ...current,
+          stress: clamp(current.stress + stressDelta, 0, 100),
+          fatigue: clamp(current.fatigue + fatigueDelta, 0, 100),
+        }
+      })
+      return next
+    })
+  }, [])
+
+  useEffect(() => {
     if (previousRouteKeyRef.current !== routeKey) {
       setProgress(0)
       setElapsedMs(0)
@@ -635,6 +1049,7 @@ function App() {
       setLogEntries([])
       setHasLaunched(false)
       setObstacles([])
+      setIsMapCollapsed(false)
       obstacleTimersRef.current.forEach((timeoutId) => clearTimeout(timeoutId))
       obstacleTimersRef.current.clear()
       if (heartbeatIntervalRef.current) {
@@ -642,23 +1057,69 @@ function App() {
         heartbeatIntervalRef.current = null
       }
       crewHeartbeatIndexRef.current = 0
+      lastElapsedRef.current = 0
+      setCrewMetrics(() => {
+        const initial = {}
+        crewState.forEach((member) => {
+          initial[member.id] = createInitialMetrics(member)
+        })
+        return initial
+      })
       previousRouteKeyRef.current = routeKey
+      setPeakTeamStress(0)
     }
-  }, [routeKey])
+  }, [routeKey, crewState])
 
-  useEffect(() => () => {
-    obstacleTimersRef.current.forEach((timeoutId) => clearTimeout(timeoutId))
-    obstacleTimersRef.current.clear()
-    if (heartbeatIntervalRef.current) {
-      clearInterval(heartbeatIntervalRef.current)
-      heartbeatIntervalRef.current = null
-    }
-  }, [])
+  useEffect(
+    () => () => {
+      obstacleTimersRef.current.forEach((timeoutId) => clearTimeout(timeoutId))
+      obstacleTimersRef.current.clear()
+      if (heartbeatIntervalRef.current) {
+        clearInterval(heartbeatIntervalRef.current)
+        heartbeatIntervalRef.current = null
+      }
+    },
+    [],
+  )
 
-  const crewSummary = useMemo(() => {
-    const grouped = groupCrewByRole(crewState)
-    return Array.from(grouped.entries()).map(([role, { units }]) => ({ role, units }))
+  useEffect(() => {
+    setCrewMetrics((metrics) => {
+      const next = { ...metrics }
+      crewState.forEach((member) => {
+        const existing = next[member.id] ?? createInitialMetrics(member)
+        const teamSize = member.teamSize ?? existing.teamSize
+        const totalTeams = Math.max(1, Math.ceil(member.units / teamSize))
+        const awakeUnits = Math.min(member.units, teamSize)
+        next[member.id] = {
+          ...existing,
+          teamSize,
+          totalTeams,
+          awakeUnits,
+          restingUnits: Math.max(0, member.units - awakeUnits),
+        }
+      })
+      return next
+    })
   }, [crewState])
+
+  const buildStressNotes = useCallback(
+    (crewId) => {
+      const metrics = crewMetricsRef.current[crewId]
+      const crewMember = crewByIdRef.current.get(crewId)
+      if (!metrics || !crewMember) return []
+      const grade = describeStressLevel(metrics.stress)
+      const efficiency = Math.round(metrics.efficiency * 100)
+      const rotation = metrics.totalTeams > 1
+        ? `${metrics.awakeUnits} on watch / ${metrics.restingUnits} resting`
+        : 'Entire team on watch'
+      return [
+        `Stress posture: ${grade.label} (${Math.round(metrics.stress)}%).`,
+        `Rotation: ${rotation}.`,
+        `Efficiency holding at ${efficiency}% for ${crewMember.role}.`,
+      ]
+    },
+    [],
+  )
 
   const availableOrigins = useMemo(() => {
     const supportedOrigins = new Set(routes.map((route) => route.origin))
@@ -761,6 +1222,8 @@ function App() {
     resolvedNow.forEach((obstacle) => {
       const config = OBSTACLE_TYPES[obstacle.type]
       if (!config) return
+      const crewIds = ['captain', 'navigator', 'operations', 'engineer', 'intel']
+      adjustCrewStress(crewIds, -5, -3)
       pushLogEntry({
         id: createId('log'),
         type: 'crew',
@@ -771,6 +1234,7 @@ function App() {
           'Confirming structural sensors back within norms.',
           'Rebalancing reactor output to standard cruise.',
           'Logging clearance with operations.',
+          ...buildStressNotes('engineer'),
         ],
         timestamp: new Date().toISOString(),
       })
@@ -780,7 +1244,7 @@ function App() {
       }, 4500)
       obstacleTimersRef.current.add(cleanupId)
     })
-  }, [progress, obstacles, pushLogEntry])
+  }, [progress, obstacles, pushLogEntry, adjustCrewStress])
 
   useEffect(() => {
     if (!currentRoute) return
@@ -801,6 +1265,7 @@ function App() {
         milestone.focusRoles.forEach(async (crewId) => {
           const crewMember = crewState.find((member) => member.id === crewId)
           if (!crewMember) return
+          adjustCrewStress([crewId], -6, -2)
           const thought = await requestCrewThought({
             crewMember,
             milestone,
@@ -814,7 +1279,7 @@ function App() {
               author: crewMember.name,
               role: crewMember.role,
               transcript: thought.transcript,
-              chainOfThought: thought.chainOfThought,
+              chainOfThought: [...thought.chainOfThought, ...buildStressNotes(crewId)],
               provider: thought.provider,
               timestamp: new Date().toISOString(),
             },
@@ -823,7 +1288,7 @@ function App() {
         })
       }
     })
-  }, [progress, currentRoute, crewState, elapsedMs, triggeredMilestones])
+  }, [progress, currentRoute, crewState, elapsedMs, triggeredMilestones, adjustCrewStress, buildStressNotes])
 
   useEffect(() => {
     if (progress >= 1 && isRunning) {
@@ -842,6 +1307,94 @@ function App() {
       ])
     }
   }, [progress, isRunning])
+
+  const updateCrewMetrics = useCallback(
+    (deltaMs) => {
+      if (!isRunning || isPaused) return
+      if (deltaMs <= 0) return
+      const deltaMissionMinutes = deltaMs / 60000
+      const deltaSimMinutes = deltaMissionMinutes * SIMULATION_MINUTES_PER_MISSION_MINUTE
+      const deltaSimHours = deltaSimMinutes / 60
+      setCrewMetrics((metrics) => {
+        const next = { ...metrics }
+        crewState.forEach((member) => {
+          const entry = next[member.id] ?? createInitialMetrics(member)
+          const teamSize = member.teamSize ?? entry.teamSize
+          const totalTeams = Math.max(1, Math.ceil(member.units / teamSize))
+          const cycleHours = SHIFT_LENGTH_HOURS * totalTeams
+          const newClock = (entry.clock + deltaSimHours) % cycleHours
+          const shiftIndex = Math.min(totalTeams - 1, Math.floor(newClock / SHIFT_LENGTH_HOURS))
+          const awakeUnits = Math.min(member.units, teamSize)
+          const restingUnits = Math.max(0, member.units - awakeUnits)
+          const awakeRatio = member.units > 0 ? awakeUnits / member.units : 1
+          const restRatio = member.units > 0 ? restingUnits / member.units : 0
+          let fatigue = entry.fatigue + deltaSimHours * (FATIGUE_RATE_ON_DUTY * awakeRatio + (restRatio === 0 ? 1.1 : 0))
+          fatigue -= deltaSimHours * FATIGUE_RECOVERY_PER_HOUR * restRatio * (1 + Math.max(0, totalTeams - 1) * 0.12)
+          fatigue = clamp(fatigue, 0, 100)
+          let stress = entry.stress + deltaSimHours * (STRESS_RATE_ON_DUTY * awakeRatio + (fatigue / 100) * STRESS_FROM_FATIGUE)
+          stress -= deltaSimHours * STRESS_RECOVERY_PER_HOUR * restRatio
+          stress = clamp(stress, 0, 100)
+          const efficiencyPenalty = fatigue * 0.004 + stress * 0.0035
+          const efficiency = clamp(1 - efficiencyPenalty, 0.35, 1)
+          next[member.id] = {
+            ...entry,
+            stress,
+            fatigue,
+            efficiency,
+            awakeUnits,
+            restingUnits,
+            totalTeams,
+            teamSize,
+            clock: newClock,
+            shiftIndex,
+          }
+        })
+        return next
+      })
+    },
+    [crewState, isPaused, isRunning],
+  )
+
+  useEffect(() => {
+    const delta = elapsedMs - lastElapsedRef.current
+    lastElapsedRef.current = elapsedMs
+    updateCrewMetrics(delta)
+  }, [elapsedMs, updateCrewMetrics])
+
+  useEffect(() => {
+    if (!isRunning || isPaused) {
+      if (heartbeatIntervalRef.current) {
+        clearInterval(heartbeatIntervalRef.current)
+        heartbeatIntervalRef.current = null
+      }
+      return undefined
+    }
+
+    const interval = setInterval(() => {
+      const sequence = HEARTBEAT_TASKS[crewHeartbeatIndexRef.current % HEARTBEAT_TASKS.length]
+      crewHeartbeatIndexRef.current += 1
+      const crewMember = crewState.find((member) => member.id === sequence.crewId)
+      if (!crewMember) return
+      const telemetry = latestTelemetryRef.current
+      const metrics = crewMetricsRef.current[crewMember.id]
+      pushLogEntry({
+        id: createId('log'),
+        type: 'crew',
+        author: crewMember.name,
+        role: crewMember.role,
+        transcript: sequence.buildTranscript({ crewMember, telemetry, metrics }),
+        chainOfThought: [...sequence.buildThoughts({ crewMember, telemetry, metrics }), ...buildStressNotes(crewMember.id)],
+        timestamp: new Date().toISOString(),
+      })
+    }, Math.max(4000, 12000 / Math.max(TIME_SCALE, 0.1)))
+
+    heartbeatIntervalRef.current = interval
+
+    return () => {
+      clearInterval(interval)
+      heartbeatIntervalRef.current = null
+    }
+  }, [isRunning, isPaused, crewState, pushLogEntry, buildStressNotes])
 
   const canStart = Boolean(currentRoute) && !isRunning
 
@@ -865,6 +1418,15 @@ function App() {
     setHasLaunched(true)
     setObstacles([])
     crewHeartbeatIndexRef.current = 0
+    lastElapsedRef.current = 0
+    setPeakTeamStress(aggregateTeamStress)
+    setCrewMetrics(() => {
+      const initial = {}
+      crewState.forEach((member) => {
+        initial[member.id] = createInitialMetrics(member)
+      })
+      return initial
+    })
   }
 
   const handlePauseToggle = () => {
@@ -881,6 +1443,7 @@ function App() {
     setLogEntries([])
     setHasLaunched(false)
     setObstacles([])
+    setIsMapCollapsed(false)
     obstacleTimersRef.current.forEach((timeoutId) => clearTimeout(timeoutId))
     obstacleTimersRef.current.clear()
     if (heartbeatIntervalRef.current) {
@@ -888,6 +1451,15 @@ function App() {
       heartbeatIntervalRef.current = null
     }
     crewHeartbeatIndexRef.current = 0
+    lastElapsedRef.current = 0
+    setPeakTeamStress(0)
+    setCrewMetrics(() => {
+      const initial = {}
+      crewState.forEach((member) => {
+        initial[member.id] = createInitialMetrics(member)
+      })
+      return initial
+    })
   }
 
   const openCrewBriefing = () => {
@@ -912,6 +1484,16 @@ function App() {
     setCrewState((state) => state.map((member) => (member.id === crewId ? { ...member, alliances } : member)))
   }
 
+  const updateUnits = (crewId, units) => {
+    setCrewState((state) =>
+      state.map((member) => {
+        if (member.id !== crewId) return member
+        const boundedUnits = clamp(units, member.minUnits, member.maxUnits)
+        return { ...member, units: boundedUnits }
+      }),
+    )
+  }
+
   const addObstacle = useCallback(
     (type) => {
       if (!currentRoute) return
@@ -929,6 +1511,7 @@ function App() {
         chainOfThought: [],
         timestamp,
       })
+      adjustCrewStress(['intel', 'captain', 'operations', 'navigator', 'engineer'], 9, 3)
       scheduleLogEntry(400, () => ({
         id: createId('log'),
         type: 'crew',
@@ -939,6 +1522,7 @@ function App() {
           'Refreshing sensor fusion loop for obstacle classification.',
           `Estimating clearance vector for ${config.label.toLowerCase()}.`,
           'Relaying recommendations to the bridge team.',
+          ...buildStressNotes('intel'),
         ],
         timestamp: new Date().toISOString(),
       }))
@@ -952,6 +1536,7 @@ function App() {
           'Reviewing analyst summary and navigational offsets.',
           'Coordinating ballast and propulsion directives.',
           'Tasking operations for contingency readiness.',
+          ...buildStressNotes('captain'),
         ],
         timestamp: new Date().toISOString(),
       }))
@@ -965,6 +1550,7 @@ function App() {
           'Paging response teams across compartments.',
           'Updating systems checklist for evolving hazard.',
           'Confirming crew execution timelines.',
+          ...buildStressNotes('operations'),
         ],
         timestamp: new Date().toISOString(),
       }))
@@ -978,46 +1564,106 @@ function App() {
           'Projecting detour across plotted bathymetry.',
           'Feeding updated waypoints to helm control.',
           'Verifying clearance margins on cable segment.',
+          ...buildStressNotes('navigator'),
         ],
         timestamp: new Date().toISOString(),
       }))
     },
-    [currentRoute, progress, pushLogEntry, scheduleLogEntry],
+    [currentRoute, progress, pushLogEntry, scheduleLogEntry, adjustCrewStress, buildStressNotes],
   )
 
+  const totalCrewUnits = useMemo(() => crewState.reduce((sum, member) => sum + member.units, 0), [crewState])
+
+  const aggregateTeamStress = useMemo(() => {
+    const values = crewState.map((member) => crewMetrics[member.id]?.stress ?? 0)
+    if (!values.length) return 0
+    return values.reduce((sum, value) => sum + value, 0) / values.length
+  }, [crewMetrics, crewState])
+
   useEffect(() => {
-    if (!isRunning || isPaused) {
-      if (heartbeatIntervalRef.current) {
-        clearInterval(heartbeatIntervalRef.current)
-        heartbeatIntervalRef.current = null
-      }
-      return undefined
-    }
+    setPeakTeamStress((prev) => Math.max(prev, aggregateTeamStress))
+  }, [aggregateTeamStress])
 
-    const interval = setInterval(() => {
-      const sequence = HEARTBEAT_TASKS[crewHeartbeatIndexRef.current % HEARTBEAT_TASKS.length]
-      crewHeartbeatIndexRef.current += 1
-      const crewMember = crewState.find((member) => member.id === sequence.crewId)
-      if (!crewMember) return
-      const telemetry = latestTelemetryRef.current
-      pushLogEntry({
-        id: createId('log'),
-        type: 'crew',
-        author: crewMember.name,
-        role: crewMember.role,
-        transcript: sequence.buildTranscript({ crewMember, telemetry }),
-        chainOfThought: sequence.buildThoughts({ crewMember, telemetry }),
-        timestamp: new Date().toISOString(),
+  const teamStressGrade = useMemo(() => describeStressLevel(aggregateTeamStress), [aggregateTeamStress])
+
+  const currentRouteDistanceNm = useMemo(() => {
+    if (!currentRoute) return 0
+    return computeRouteDistanceNauticalMiles(currentRoute.path)
+  }, [currentRoute])
+
+  const remainingNauticalMiles = useMemo(() => {
+    if (!currentRouteDistanceNm) return 0
+    return Math.max(0, currentRouteDistanceNm * (1 - progress))
+  }, [currentRouteDistanceNm, progress])
+
+  const elapsedSimHours = useMemo(() => {
+    const missionMinutes = elapsedMs / 60000
+    const simMinutes = missionMinutes * SIMULATION_MINUTES_PER_MISSION_MINUTE
+    return simMinutes / 60
+  }, [elapsedMs])
+
+  const stressFactor = 1 + (aggregateTeamStress / 100) * STRESS_FUEL_MULTIPLIER
+  const burnRate = useMemo(() => {
+    const baseRate = BASE_FUEL_BURN_PER_HOUR + totalCrewUnits * ADDITIONAL_BURN_PER_CREW_UNIT
+    return baseRate * stressFactor
+  }, [totalCrewUnits, stressFactor])
+
+  const fuelConsumedLiters = burnRate * elapsedSimHours
+  const fuelPercentage = clamp((fuelConsumedLiters / FUEL_TANK_CAPACITY_LITERS) * 100, 0, 100)
+  const enduranceHours = burnRate > 0 ? FUEL_TANK_CAPACITY_LITERS / burnRate : 0
+  const projectedRangeNm = burnRate > 0 ? Math.max(0, (FUEL_TANK_CAPACITY_LITERS - fuelConsumedLiters) / burnRate) * 18 : 0
+
+  const resourceStats = {
+    burnRate,
+    fuelConsumedLiters,
+    fuelPercentage,
+    enduranceHours,
+    tankCapacity: FUEL_TANK_CAPACITY_LITERS,
+    stressFactor,
+    projectedRangeNm,
+  }
+
+  const depthMeters = useMemo(() => {
+    if (!currentRoute) return 0
+    const baseDepth = 210
+    const wave = Math.sin(progress * Math.PI * 1.2) * 35
+    const obstacleLoad = obstacles.filter((obstacle) => !obstacle.resolved).length * 12
+    const stressEffect = aggregateTeamStress * 0.4
+    const milestoneRelief = triggeredMilestones.length * -5
+    const value = baseDepth + wave + obstacleLoad + stressEffect + milestoneRelief
+    return Math.round(clamp(value, 120, 360))
+  }, [currentRoute, progress, obstacles, aggregateTeamStress, triggeredMilestones])
+
+  const telemetrySummary = {
+    elapsedLabel: formatTime(elapsedMs),
+    milestonesLabel: `${triggeredMilestones.length}/${currentRoute?.milestones.length ?? 0}`,
+    remainingDistanceLabel: formatNauticalMiles(remainingNauticalMiles),
+    depthLabel: `${depthMeters} m`,
+    crewLabel: `${totalCrewUnits} specialists`,
+    crewUnits: totalCrewUnits,
+  }
+
+  const rotationSummary = useMemo(() => {
+    const rotations = crewState
+      .map((member) => {
+        const metrics = crewMetrics[member.id]
+        if (!metrics) return null
+        if (metrics.totalTeams <= 1) {
+          return `${member.role}: no reserve rotation`
+        }
+        const shiftProgress = metrics.clock % SHIFT_LENGTH_HOURS
+        const hours = shiftProgress === 0 ? SHIFT_LENGTH_HOURS : SHIFT_LENGTH_HOURS - shiftProgress
+        return `${member.role}: next team in ${formatHours(hours)}`
       })
-    }, Math.max(4000, 12000 / Math.max(TIME_SCALE, 0.1)))
-
-    heartbeatIntervalRef.current = interval
-
-    return () => {
-      clearInterval(interval)
-      heartbeatIntervalRef.current = null
+      .filter(Boolean)
+    if (!rotations.length) {
+      return 'Rotation schedule preparing.'
     }
-  }, [isRunning, isPaused, crewState, pushLogEntry])
+    return rotations[0]
+  }, [crewState, crewMetrics])
+
+  const aggregateMilestoneSummary = `${triggeredMilestones.length}/${currentRoute?.milestones.length ?? 0} milestones`
+
 
   return (
     <div
@@ -1032,7 +1678,13 @@ function App() {
       }
     >
       <CrewSidebar
-        crewSummary={crewSummary}
+        crewState={crewState}
+        crewMetrics={crewMetrics}
+        aggregateStress={aggregateTeamStress}
+        stressGrade={teamStressGrade}
+        totalCrewUnits={totalCrewUnits}
+        rotationSummary={rotationSummary}
+        peakTeamStress={peakTeamStress}
         onOpenBriefing={openCrewBriefing}
         isPaused={isPaused}
         canResume={isRunning}
@@ -1082,14 +1734,27 @@ function App() {
           obstacles={obstacles}
           onAddObstacle={addObstacle}
           isRunning={isRunning && !isPaused}
+          isCollapsed={isMapCollapsed}
+          onToggleCollapse={() => setIsMapCollapsed((state) => !state)}
+          telemetrySummary={{
+            ...telemetrySummary,
+            milestonesLabel: aggregateMilestoneSummary,
+          }}
+          resourceStats={resourceStats}
+          aggregateStress={aggregateTeamStress}
+          stressGrade={teamStressGrade}
         />
       </main>
       {isCrewExpanded ? (
         <CrewBriefingOverlay
           crewState={crewState}
+          crewMetrics={crewMetrics}
           onClose={closeCrewBriefing}
           onUpdateInstructions={updateInstructions}
           onUpdateAlliances={updateAlliances}
+          onUpdateUnits={updateUnits}
+          canModifyStaffing={!hasLaunched}
+          resourceStats={resourceStats}
         />
       ) : null}
     </div>

--- a/src/data/crew.js
+++ b/src/data/crew.js
@@ -4,6 +4,9 @@ export const crew = [
     name: 'Captain Mira Chen',
     role: 'Mission Command',
     units: 1,
+    minUnits: 1,
+    maxUnits: 2,
+    teamSize: 1,
     defaultInstructions:
       'Authorize route changes and prioritise stealth when approaching chokepoints or heavily trafficked cables.',
     alliances: ['navigator', 'intel'],
@@ -13,6 +16,9 @@ export const crew = [
     name: 'Lieutenant Theo Park',
     role: 'Navigation',
     units: 4,
+    minUnits: 2,
+    maxUnits: 6,
+    teamSize: 2,
     defaultInstructions:
       'Maintain geodesic progress and adjust ballast to trace cable bathymetry without exceeding hull strain.',
     alliances: ['captain', 'engineer'],
@@ -22,6 +28,9 @@ export const crew = [
     name: 'Chief Ava Rahman',
     role: 'Engineering',
     units: 6,
+    minUnits: 4,
+    maxUnits: 8,
+    teamSize: 2,
     defaultInstructions:
       'Distribute reactor output to propulsion pods and heat exchangers while monitoring vibration signatures.',
     alliances: ['navigator', 'operations'],
@@ -31,15 +40,21 @@ export const crew = [
     name: 'Warrant Jorge Ibarra',
     role: 'Operations Control',
     units: 3,
+    minUnits: 2,
+    maxUnits: 5,
+    teamSize: 2,
     defaultInstructions:
       'Coordinate damage control parties, sensor calibration crews, and cable interface specialists.',
     alliances: ['engineer', 'intel'],
   },
   {
     id: 'intel',
-    name: 'Analyst Priya N\'Dour',
+    name: "Analyst Priya N'Dour",
     role: 'Intelligence',
     units: 2,
+    minUnits: 1,
+    maxUnits: 4,
+    teamSize: 1,
     defaultInstructions:
       'Fuse maritime intelligence, weather overlays, and network outage telemetry to predict hazards.',
     alliances: ['captain', 'operations'],


### PR DESCRIPTION
## Summary
- implement comprehensive crew stress, fatigue, and sleep-cycle simulation with dynamic resource modeling and telemetry statistics in the main dashboard
- enhance sidebar and crew briefing interfaces with stress visualizations, staffing adjustments, and resource summaries, including peak team stress tracking
- add collapsible map panel displaying mission telemetry and resource analytics alongside updated map overlays and resource grid styling
- extend the crew manifest to support staffing limits and team rotation metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d889b24b98832e86e216cad3113d83