### PR TITLE
Add ship log persistence and mission completion review

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,14 @@
-from typing import List, Optional
+import io
+import json
+from datetime import datetime, timedelta
+from threading import Lock
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import AliasChoices, BaseModel, Field, ConfigDict
 
 from .agents import AgentOrchestrator, format_drift, format_heading, synthesise_fallback
 
@@ -58,6 +64,44 @@ class CrewThoughtResponse(BaseModel):
     transcript: str
     chain_of_thought: List[str]
     provider: str = "agents-backend"
+    conversation: List[Dict[str, str]] = Field(default_factory=list)
+    log_entry_id: Optional[str] = None
+
+
+class ShipLogEntryPayload(BaseModel):
+    """Payload used to persist entries inside the backend logbook."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    id: Optional[str] = None
+    timestamp: Optional[datetime] = None
+    entry_type: str = Field(default="system", alias="type")
+    author: str
+    role: Optional[str] = None
+    transcript: str
+    chain_of_thought: List[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("chain_of_thought", "chainOfThought"),
+    )
+    provider: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    conversation: Optional[List[Dict[str, str]]] = Field(
+        default=None,
+        validation_alias=AliasChoices("conversation", "conversation_history"),
+    )
+
+
+class ShipLogEntryResponse(BaseModel):
+    id: str
+    timestamp: str
+    type: str
+    author: str
+    role: Optional[str] = None
+    transcript: str
+    chain_of_thought: List[str] = Field(default_factory=list)
+    provider: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    conversation: List[Dict[str, str]] = Field(default_factory=list)
 
 
 app = FastAPI(title="Submarine Agents Backend")
@@ -69,6 +113,125 @@ app.add_middleware(
 )
 
 orchestrator = AgentOrchestrator()
+
+_ship_log_entries: List[ShipLogEntryResponse] = []
+_ship_log_lock = Lock()
+_MAX_LOG_ENTRIES = 2000
+
+
+def _serialize_timestamp(value: datetime) -> str:
+    return value.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _record_ship_log_entry(payload: ShipLogEntryPayload) -> ShipLogEntryResponse:
+    timestamp = payload.timestamp or datetime.utcnow()
+    entry_id = payload.id or f"log-{uuid4()}"
+    record = ShipLogEntryResponse(
+        id=entry_id,
+        timestamp=_serialize_timestamp(timestamp),
+        type=payload.entry_type,
+        author=payload.author,
+        role=payload.role,
+        transcript=payload.transcript,
+        chain_of_thought=list(payload.chain_of_thought),
+        provider=payload.provider,
+        metadata=payload.metadata or {},
+        conversation=list(payload.conversation or []),
+    )
+    with _ship_log_lock:
+        _ship_log_entries.append(record)
+        if len(_ship_log_entries) > _MAX_LOG_ENTRIES:
+            del _ship_log_entries[: len(_ship_log_entries) - _MAX_LOG_ENTRIES]
+    return record
+
+
+def _get_ship_log_entries() -> List[ShipLogEntryResponse]:
+    with _ship_log_lock:
+        return list(_ship_log_entries)
+
+
+def _reset_ship_log() -> None:
+    with _ship_log_lock:
+        _ship_log_entries.clear()
+
+
+def _parse_timestamp(value: str) -> Optional[datetime]:
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _format_duration(delta: timedelta) -> Optional[str]:
+    total_seconds = int(delta.total_seconds())
+    if total_seconds <= 0:
+        return None
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, _seconds = divmod(remainder, 60)
+    parts: List[str] = []
+    if hours:
+        parts.append(f"{hours} hour{'s' if hours != 1 else ''}")
+    if minutes:
+        parts.append(f"{minutes} minute{'s' if minutes != 1 else ''}")
+    if not parts:
+        parts.append("moments")
+    return " and ".join(parts)
+
+
+def _build_ship_log_story(entries: List[ShipLogEntryResponse]) -> str:
+    if not entries:
+        return "No ship log entries were recorded for this voyage."
+
+    ordered = sorted(entries, key=lambda item: item.timestamp)
+    start_time = _parse_timestamp(ordered[0].timestamp)
+    end_time = _parse_timestamp(ordered[-1].timestamp)
+    duration_label: Optional[str] = None
+    if start_time and end_time:
+        duration_label = _format_duration(end_time - start_time)
+
+    total_entries = len(entries)
+    system_events = [entry for entry in ordered if entry.type == "system"]
+    reflection_events = [entry for entry in ordered if entry.type == "reflection"]
+    crew_updates = [entry for entry in ordered if entry.type in {"crew", "reflection"}]
+
+    paragraphs: List[str] = []
+    opening = (
+        f"The ship's log captures {total_entries} coordinated updates"
+        if total_entries != 1
+        else "The ship's log captures a single coordinated update"
+    )
+    if duration_label:
+        opening += f" across {duration_label}."
+    else:
+        opening += "."
+    paragraphs.append(opening)
+
+    if system_events:
+        highlights = ", ".join(
+            event.transcript.split(".")[0] for event in system_events[:3]
+        )
+        paragraphs.append(
+            "Mission waypoints and alerts were marked by the control team: "
+            f"{highlights}."
+        )
+
+    if reflection_events:
+        paragraphs.append(
+            "Crew reflections surfaced on a steady cadence, allowing every department to "
+            "voice morale and emotional posture as the voyage advanced."
+        )
+
+    if crew_updates:
+        final_update = crew_updates[-1]
+        closing = final_update.transcript.strip()
+        paragraphs.append(
+            "The journey closed with "
+            f"{final_update.author}'s words: \"{closing}\""
+        )
+
+    return "\n\n".join(paragraphs)
 
 
 def _prepare_context(payload: CrewThoughtRequest) -> dict:
@@ -103,16 +266,54 @@ def _build_response_from_conversation(conversation: List[dict]) -> CrewThoughtRe
         raise ValueError("Conversation was empty")
     final_entry = conversation[-1]
     thought_lines: List[str] = []
-    for entry in conversation[:-1]:
-        for raw_line in entry["content"].splitlines():
-            cleaned = raw_line.strip().lstrip("-•·").strip()
+    conversation_records: List[Dict[str, str]] = []
+    for entry in conversation:
+        role = entry.get("role", "crew")
+        content = entry.get("content", "")
+        conversation_records.append({"role": role, "content": content})
+        for raw_line in content.splitlines():
+            cleaned = raw_line.strip()
             if cleaned:
-                thought_lines.append(cleaned)
+                thought_lines.append(f"{role.title()}: {cleaned}")
     return CrewThoughtResponse(
         transcript=final_entry["content"],
         chain_of_thought=thought_lines,
         provider="agents-backend",
+        conversation=conversation_records,
     )
+
+
+def _log_crew_thought(
+    context: Dict[str, Any],
+    request: CrewThoughtRequest,
+    response: CrewThoughtResponse,
+) -> CrewThoughtResponse:
+    metadata = {
+        "crew_id": request.crew_member.id,
+        "crew_role": request.crew_member.role,
+        "milestone_id": request.milestone.id,
+        "milestone_label": request.milestone.label,
+        "route_id": request.route.id,
+        "route_name": request.route.name,
+        "elapsed_minutes": context.get("elapsed_minutes"),
+        "progress_percent": context.get("progress"),
+        "telemetry": context.get("telemetry"),
+        "metrics": context.get("metrics"),
+        "source": "crew_thought",
+    }
+    entry = ShipLogEntryPayload(
+        id=response.log_entry_id,
+        entry_type="crew",
+        author=request.crew_member.name,
+        role=request.crew_member.role,
+        transcript=response.transcript,
+        chain_of_thought=response.chain_of_thought,
+        provider=response.provider,
+        metadata=metadata,
+        conversation=response.conversation,
+    )
+    record = _record_ship_log_entry(entry)
+    return response.model_copy(update={"log_entry_id": record.id})
 
 
 @app.post("/api/crew/thought", response_model=CrewThoughtResponse)
@@ -121,11 +322,53 @@ async def create_crew_thought(payload: CrewThoughtRequest) -> CrewThoughtRespons
     if orchestrator.is_available():
         try:
             conversation = orchestrator.run(context)
-            return _build_response_from_conversation(conversation)
+            response = _build_response_from_conversation(conversation)
+            return _log_crew_thought(context, payload, response)
         except HTTPException:
             raise
         except Exception:  # pragma: no cover - defensive logging
             fallback = synthesise_fallback(context)
-            return CrewThoughtResponse(**fallback)
+            response = CrewThoughtResponse(**fallback)
+            return _log_crew_thought(context, payload, response)
     fallback = synthesise_fallback(context)
-    return CrewThoughtResponse(**fallback)
+    response = CrewThoughtResponse(**fallback)
+    return _log_crew_thought(context, payload, response)
+
+
+@app.post("/api/log", response_model=ShipLogEntryResponse)
+def append_ship_log(entry: ShipLogEntryPayload) -> ShipLogEntryResponse:
+    return _record_ship_log_entry(entry)
+
+
+@app.get("/api/log", response_model=List[ShipLogEntryResponse])
+def list_ship_log() -> List[ShipLogEntryResponse]:
+    return _get_ship_log_entries()
+
+
+@app.delete("/api/log")
+def clear_ship_log() -> JSONResponse:
+    _reset_ship_log()
+    return JSONResponse({"status": "cleared"})
+
+
+@app.get("/api/log/download")
+def download_ship_log() -> StreamingResponse:
+    entries = _get_ship_log_entries()
+    payload = {
+        "exported_at": _serialize_timestamp(datetime.utcnow()),
+        "entry_count": len(entries),
+        "entries": [entry.model_dump() for entry in entries],
+    }
+    data = json.dumps(payload, ensure_ascii=False, indent=2)
+    buffer = io.BytesIO(data.encode("utf-8"))
+    buffer.seek(0)
+    filename = f"ship-log-{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}" + ".json"
+    headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
+    return StreamingResponse(buffer, media_type="application/json", headers=headers)
+
+
+@app.get("/api/log/story")
+def ship_log_story() -> Dict[str, Any]:
+    entries = _get_ship_log_entries()
+    story = _build_ship_log_story(entries)
+    return {"story": story, "entry_count": len(entries)}

--- a/src/App.css
+++ b/src/App.css
@@ -503,6 +503,52 @@ body {
   align-items: stretch;
 }
 
+.mission-complete-panel {
+  background: rgba(8, 22, 44, 0.92);
+  border: 1px solid rgba(94, 146, 231, 0.45);
+  border-radius: 20px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.55rem;
+  min-width: 220px;
+  max-width: 260px;
+  flex: 0 0 240px;
+  box-shadow: 0 8px 18px rgba(8, 18, 36, 0.45);
+}
+
+.mission-complete-panel__status,
+.mission-complete-panel__review {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(114, 165, 255, 0.5);
+  background: linear-gradient(135deg, rgba(13, 36, 74, 0.95), rgba(18, 54, 92, 0.95));
+  color: #f5f8ff;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.mission-complete-panel__status {
+  cursor: default;
+}
+
+.mission-complete-panel__review {
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.mission-complete-panel__review:hover {
+  background: linear-gradient(135deg, rgba(20, 58, 104, 0.95), rgba(30, 78, 126, 0.95));
+  transform: translateY(-1px);
+}
+
+.mission-complete-panel__story-status {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(198, 212, 245, 0.8);
+}
+
 .route-selector {
   background: rgba(7, 21, 36, 0.92);
   border: 1px solid rgba(65, 110, 199, 0.35);
@@ -817,10 +863,34 @@ body {
   flex: 0 0 auto;
 }
 
-.ship-log h2 {
+.ship-log__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ship-log__header h2 {
   margin: 0;
   font-size: 1.1rem;
   letter-spacing: 0.03em;
+}
+
+.ship-log__header button {
+  padding: 0.45rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid rgba(88, 135, 214, 0.5);
+  background: rgba(9, 24, 46, 0.92);
+  color: #f4f7ff;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+
+.ship-log__header button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .ship-log__empty {
@@ -869,6 +939,184 @@ body {
   gap: 0.3rem;
   font-size: 0.85rem;
   color: rgba(210, 226, 255, 0.88);
+}
+
+.ship-log-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 10, 22, 0.9);
+  backdrop-filter: blur(6px);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 3rem 2rem;
+  z-index: 40;
+  overflow-y: auto;
+}
+
+.ship-log-overlay__content {
+  background: rgba(6, 18, 36, 0.96);
+  border-radius: 24px;
+  border: 1px solid rgba(94, 143, 232, 0.45);
+  width: min(960px, 100%);
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 24px 64px rgba(4, 12, 28, 0.6);
+}
+
+.ship-log-overlay__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.ship-log-overlay__header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.04em;
+}
+
+.ship-log-overlay__header p {
+  margin: 0.4rem 0 0;
+  color: rgba(196, 214, 249, 0.78);
+  font-size: 0.9rem;
+}
+
+.ship-log-overlay__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.ship-log-overlay__actions button {
+  padding: 0.55rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(118, 172, 255, 0.55);
+  background: linear-gradient(135deg, rgba(18, 52, 94, 0.98), rgba(26, 68, 120, 0.98));
+  color: #f2f6ff;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  cursor: pointer;
+}
+
+.ship-log-overlay__actions button:last-child {
+  background: rgba(12, 32, 60, 0.95);
+}
+
+.ship-log-overlay__story,
+.ship-log-overlay__timeline {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.ship-log-overlay__story h3,
+.ship-log-overlay__timeline h3 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(205, 219, 252, 0.9);
+}
+
+.ship-log-overlay__story p {
+  margin: 0;
+  line-height: 1.5;
+  color: rgba(210, 225, 255, 0.9);
+}
+
+.ship-log-overlay__status {
+  margin: 0;
+  color: rgba(195, 214, 249, 0.82);
+  font-style: italic;
+}
+
+.ship-log-overlay__status--error {
+  color: #ffb8b3;
+}
+
+.ship-log-overlay__timeline ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.ship-log-overlay__entry {
+  background: rgba(10, 28, 54, 0.7);
+  border: 1px solid rgba(105, 152, 233, 0.4);
+  border-radius: 16px;
+  padding: 1rem 1.2rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.ship-log-overlay__entry header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  align-items: baseline;
+}
+
+.ship-log-overlay__entry-time {
+  font-size: 0.78rem;
+  color: rgba(184, 206, 244, 0.75);
+}
+
+.ship-log-overlay__entry-author {
+  font-weight: 600;
+  color: #f4f8ff;
+}
+
+.ship-log-overlay__entry-role {
+  font-size: 0.78rem;
+  color: rgba(194, 212, 245, 0.78);
+}
+
+.ship-log-overlay__entry-type {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(40, 90, 160, 0.35);
+  color: rgba(214, 228, 255, 0.85);
+}
+
+.ship-log-overlay__entry-type--system {
+  background: rgba(120, 160, 255, 0.25);
+}
+
+.ship-log-overlay__entry-type--crew {
+  background: rgba(111, 198, 255, 0.25);
+}
+
+.ship-log-overlay__entry-type--reflection {
+  background: rgba(255, 183, 120, 0.25);
+}
+
+.ship-log-overlay__entry p {
+  margin: 0;
+  color: rgba(209, 225, 255, 0.9);
+}
+
+.ship-log-overlay__entry ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.3rem;
+  color: rgba(212, 226, 255, 0.9);
+}
+
+.ship-log-overlay__conversation {
+  color: rgba(204, 219, 250, 0.9);
+}
+
+.ship-log-overlay__conversation summary {
+  cursor: pointer;
+  font-weight: 600;
 }
 
 .map-panel {
@@ -1375,6 +1623,12 @@ body {
 
   .top-controls {
     flex-direction: column;
+  }
+
+  .mission-complete-panel {
+    width: 100%;
+    max-width: none;
+    flex: 1 1 auto;
   }
 
   .mission-controls {

--- a/src/services/logbook.js
+++ b/src/services/logbook.js
@@ -1,0 +1,81 @@
+import { BACKEND_URL } from './openaiResponses.js'
+
+function buildBackendUrl(path) {
+  return `${BACKEND_URL.replace(/\/$/, '')}${path}`
+}
+
+export async function recordShipLogEntry(entry) {
+  if (!entry) return null
+  const payload = { ...entry }
+  if (!payload.id) delete payload.id
+  if ('persistedByBackend' in payload) {
+    delete payload.persistedByBackend
+  }
+  if (!Array.isArray(payload.chainOfThought) && Array.isArray(payload.chain_of_thought)) {
+    payload.chainOfThought = payload.chain_of_thought
+    delete payload.chain_of_thought
+  }
+  if (!Array.isArray(payload.chainOfThought)) {
+    payload.chainOfThought = []
+  }
+  if (!Array.isArray(payload.conversation)) {
+    delete payload.conversation
+  }
+  if (!payload.metadata || typeof payload.metadata !== 'object') {
+    delete payload.metadata
+  }
+  if (!payload.provider) {
+    delete payload.provider
+  }
+  const response = await fetch(buildBackendUrl('/api/log'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to persist log entry (status ${response.status})`)
+  }
+  return response.json()
+}
+
+export async function resetShipLog() {
+  const response = await fetch(buildBackendUrl('/api/log'), {
+    method: 'DELETE',
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to reset ship log (status ${response.status})`)
+  }
+}
+
+export async function fetchShipLogStory() {
+  const response = await fetch(buildBackendUrl('/api/log/story'))
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ship log story (status ${response.status})`)
+  }
+  const data = await response.json()
+  return { story: data.story ?? '', entryCount: data.entry_count ?? data.entryCount ?? 0 }
+}
+
+export async function downloadShipLog() {
+  const response = await fetch(buildBackendUrl('/api/log/download'))
+  if (!response.ok) {
+    throw new Error(`Failed to download ship log (status ${response.status})`)
+  }
+  const blob = await response.blob()
+  const disposition = response.headers.get('Content-Disposition') || ''
+  let filename = 'ship-log.json'
+  const match = disposition.match(/filename="?([^";]+)"?/i)
+  if (match && match[1]) {
+    filename = match[1]
+  }
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}

--- a/src/services/openaiResponses.js
+++ b/src/services/openaiResponses.js
@@ -1,4 +1,4 @@
-const BACKEND_URL = import.meta.env.VITE_BACKEND_URL ?? 'http://localhost:8000'
+export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL ?? 'http://localhost:8000'
 const REQUEST_TIMEOUT_MS = 30000
 
 function sanitizeInstructions(value) {
@@ -131,6 +131,8 @@ export async function requestCrewThought({
       : Array.isArray(result.chainOfThought)
         ? result.chainOfThought
         : []
+    const conversation = Array.isArray(result.conversation) ? result.conversation : []
+    const logEntryId = result.log_entry_id ?? result.logEntryId ?? null
     if (!transcript) {
       throw new Error('Backend did not return transcript content')
     }
@@ -138,6 +140,8 @@ export async function requestCrewThought({
       transcript,
       chainOfThought: chain,
       provider: result.provider ?? 'agents-backend',
+      conversation,
+      logEntryId,
     }
   } catch (error) {
     console.warn('Falling back to onboard reasoning:', error)


### PR DESCRIPTION
## Summary
- persist ship log entries on the backend with download and narrative endpoints
- capture backend metadata in crew thought responses and expose logbook API helpers on the frontend
- surface mission-complete controls with a full-screen log overlay and scheduled crew reflections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d89e2fdf08832e802c7bd56c3c5d25